### PR TITLE
Feature/custom subscribe

### DIFF
--- a/Example/FayeSwift.xcodeproj/xcshareddata/xcschemes/FayeSwift-Example.xcscheme
+++ b/Example/FayeSwift.xcodeproj/xcshareddata/xcschemes/FayeSwift-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/FayeSwift/ViewController.swift
+++ b/Example/FayeSwift/ViewController.swift
@@ -32,8 +32,6 @@ class ViewController: UIViewController, UITextFieldDelegate, FayeClientDelegate 
     }
     client.subscribeToChannel("/awesome", block: channelBlock)
     
-    
-    
     let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(5 * Double(NSEC_PER_SEC)))
     dispatch_after(delayTime, dispatch_get_main_queue()) {
       self.client.unsubscribeFromChannel("/awesome")
@@ -42,8 +40,12 @@ class ViewController: UIViewController, UITextFieldDelegate, FayeClientDelegate 
     dispatch_after(delayTime, dispatch_get_main_queue()) {
       let model = FayeSubscriptionModel(subscription: "/awesome", clientId: nil)
         
-      self.client.subscribeToChannel(model, block: { (messages) in
+      self.client.subscribeToChannel(model, block: { [unowned self] messages in
         print("awesome response: \(messages)")
+        
+        self.client.sendPing("Ping".dataUsingEncoding(NSUTF8StringEncoding)!, completion: {
+          print("got pong")
+        })
       })
     }
   }

--- a/Example/FayeSwift/ViewController.swift
+++ b/Example/FayeSwift/ViewController.swift
@@ -87,4 +87,8 @@ class ViewController: UIViewController, UITextFieldDelegate, FayeClientDelegate 
     let text: AnyObject? = messageDict["text"]
     print("Here is the message: \(text)")
   }
+  
+  func pongReceived(client: FayeClient) {
+    print("pong")
+  }
 }

--- a/Example/FayeSwift/ViewController.swift
+++ b/Example/FayeSwift/ViewController.swift
@@ -79,7 +79,7 @@ class ViewController: UIViewController, UITextFieldDelegate, FayeClientDelegate 
     print("Unsubscribed from channel \(channel)")
   }
   
-  func subscriptionFailedWithError(client: FayeClient, error: String) {
+  func subscriptionFailedWithError(client: FayeClient, error: subscriptionError) {
     print("Subscription failed")
   }
   

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,8 @@
 source 'https://github.com/CocoaPods/Specs.git'
+
 use_frameworks!
+inhibit_all_warnings!
+platform :ios, '8.0'
 
 target 'FayeSwift_Example', :exclusive => true do
   pod 'FayeSwift', :path => '../'
@@ -7,6 +10,4 @@ end
 
 target 'FayeSwift_Tests', :exclusive => true do
   pod 'FayeSwift', :path => '../'
-
-  
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - FayeSwift (0.1.0):
-    - Starscream (~> 1.1)
-    - SwiftyJSON (~> 2.3)
-  - Starscream (1.1.1)
+  - FayeSwift (0.2.0):
+    - Starscream
+    - SwiftyJSON
+  - Starscream (1.1.3)
   - SwiftyJSON (2.3.2)
 
 DEPENDENCIES:
@@ -13,8 +13,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FayeSwift: c4aa317bc8958a27f9152551ad39ae34e6106f9e
-  Starscream: d74dd8d122a6abd244d8d5e51f32891c796d0827
+  FayeSwift: 0d22961a961aa439d1aeb6992a7cf5454bb648a3
+  Starscream: d662732354b40dd19ed1ece3e3c44c80b536b83c
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Local Podspecs/FayeSwift.podspec.json
+++ b/Example/Pods/Local Podspecs/FayeSwift.podspec.json
@@ -1,8 +1,8 @@
 {
   "name": "FayeSwift",
-  "version": "0.1.0",
-  "summary": "A short description of FayeSwift.",
-  "description": "",
+  "version": "0.2.0",
+  "summary": "A pure Swift Faye (Bayeux) Client",
+  "description": "A Pure Swift Client Library for the Faye (Bayeux/Comet) Pub-Sub messaging server.\nThis client has been tested with the Faye (http://faye.jcoglan.com) implementation of the\nBayeux protocol. Currently only supports Websocket transport.",
   "homepage": "https://github.com/hamin/FayeSwift",
   "license": "MIT",
   "authors": {
@@ -10,23 +10,22 @@
   },
   "source": {
     "git": "https://github.com/hamin/FayeSwift.git",
-    "tag": "0.1.0"
+    "tag": "0.2.0"
   },
   "social_media_url": "https://twitter.com/harisamin",
   "requires_arc": true,
   "platforms": {
     "osx": "10.9",
     "ios": "8.0",
-    "watchos": "2.0",
     "tvos": "9.0"
   },
   "source_files": "Sources/*.swift",
   "dependencies": {
     "Starscream": [
-      "~> 1.1"
+
     ],
     "SwiftyJSON": [
-      "~> 2.3"
+
     ]
   }
 }

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,8 +1,8 @@
 PODS:
-  - FayeSwift (0.1.0):
-    - Starscream (~> 1.1)
-    - SwiftyJSON (~> 2.3)
-  - Starscream (1.1.1)
+  - FayeSwift (0.2.0):
+    - Starscream
+    - SwiftyJSON
+  - Starscream (1.1.3)
   - SwiftyJSON (2.3.2)
 
 DEPENDENCIES:
@@ -13,8 +13,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FayeSwift: c4aa317bc8958a27f9152551ad39ae34e6106f9e
-  Starscream: d74dd8d122a6abd244d8d5e51f32891c796d0827
+  FayeSwift: 0d22961a961aa439d1aeb6992a7cf5454bb648a3
+  Starscream: d662732354b40dd19ed1ece3e3c44c80b536b83c
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,1098 +1,2718 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		0D76A5AF0D4781BFAC4D92B66E3A30B4 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */; };
-		112044DE1A7A5E8036447F0CC4CA58CB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		172D87FC5B15E2E05E643DD1188F953D /* FayeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1D9F765D7226F81517EEACB2B6EE02D6 /* SwiftyJSON-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28E4BFBF9D2ACEADF06BE12B21BDFFBB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		4F6AB79FA2ADEC11423A3782E26DC919 /* FayeSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3928AADA2DE31A1110577AFF292046A8 /* FayeSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5205B3C8BA6B671C4778F40FFC7FA2AC /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5B06E0872ABFC40563F3AA7BC14A699F /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		66A658DA4AA077462390CB0E887E48E5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		70D1C0428C900D6671409303C06593E3 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA68C21BEA9C15F85E840F5BCD06B262 /* Transport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		71A71AB65AF6D4590B241277504532F1 /* FayeClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7B376196BBC05D9BB79CB4D466E47F1A /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */; };
-		968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		A07DDD4070D07F0518CC9913F4C9E2D6 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A9DB76C98B77BAC9C5FB4172E70966EB /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
-		C5681A6362FFDCE2DECBDEE5BFBC907C /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
-		D5766AF41CCE103900222792 /* FayeSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5766AF31CCE103900222792 /* FayeSubscriptionModel.swift */; };
-		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
-		E5F282A8CE41FC1844203FB427A39226 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F1C91701EDE25A8DF650080551A1EE5F /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F465C9735101FE983DA25543F4066F9A /* WebsocketTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDDE3F7149F856AAB928833D5658DB3 /* WebsocketTransport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F8555866B482E99822581ABC579F3CD5 /* SwiftyJSON-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */; };
-		FF0CA1F99F12CC1A9B852F6601921D99 /* FayeSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		002C971AF7CA74392977401F3B5915E3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0FFB2621535432DEA9289D0F9EEEE26C;
-			remoteInfo = Starscream;
-		};
-		252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0FFB2621535432DEA9289D0F9EEEE26C;
-			remoteInfo = Starscream;
-		};
-		3BD0A2C746E213094BBD1A609EE7575F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 72A65D8E20A55005994AAC51F0764161;
-			remoteInfo = SwiftyJSON;
-		};
-		6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A64AB5E2E8029DC851944646B9BCCBB2;
-			remoteInfo = FayeSwift;
-		};
-		85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0FFB2621535432DEA9289D0F9EEEE26C;
-			remoteInfo = Starscream;
-		};
-		A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 72A65D8E20A55005994AAC51F0764161;
-			remoteInfo = SwiftyJSON;
-		};
-		B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A64AB5E2E8029DC851944646B9BCCBB2;
-			remoteInfo = FayeSwift;
-		};
-		E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 72A65D8E20A55005994AAC51F0764161;
-			remoteInfo = SwiftyJSON;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Example-umbrella.h"; sourceTree = "<group>"; };
-		0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
-		0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
-		10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Tests-umbrella.h"; sourceTree = "<group>"; };
-		14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-frameworks.sh"; sourceTree = "<group>"; };
-		154C747E02B1DCBD4885645B5878477F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Starscream-dummy.m"; sourceTree = "<group>"; };
-		1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Tests-dummy.m"; sourceTree = "<group>"; };
-		1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
-		2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
-		293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
-		2A8281B38766D2C9957F19E11DA20796 /* FayeSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = FayeSwift.modulemap; sourceTree = "<group>"; };
-		2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		2FDDE3F7149F856AAB928833D5658DB3 /* WebsocketTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebsocketTransport.swift; sourceTree = "<group>"; };
-		2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Example-dummy.m"; sourceTree = "<group>"; };
-		37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Example.modulemap"; sourceTree = "<group>"; };
-		38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Source/SSLSecurity.swift; sourceTree = "<group>"; };
-		3928AADA2DE31A1110577AFF292046A8 /* FayeSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-umbrella.h"; sourceTree = "<group>"; };
-		3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-prefix.pch"; sourceTree = "<group>"; };
-		47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.xcconfig; sourceTree = "<group>"; };
-		4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-resources.sh"; sourceTree = "<group>"; };
-		4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
-		6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftyJSON-dummy.m"; sourceTree = "<group>"; };
-		6E1FB52B709CB783F4109CA61174C28B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		77F9AA324F09A90FB80ECB48C4E4BA1A /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FayeSwift.xcconfig; sourceTree = "<group>"; };
-		87D64F48FA18233694918281C87E0266 /* WebSocket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Source/WebSocket.swift; sourceTree = "<group>"; };
-		9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClientDelegate.swift; sourceTree = "<group>"; };
-		B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Helper.swift"; sourceTree = "<group>"; };
-		B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FayeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-resources.sh"; sourceTree = "<group>"; };
-		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BA68C21BEA9C15F85E840F5BCD06B262 /* Transport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
-		CFB3E404A66EE13E14582416D200A72C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
-		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
-		D5766AF31CCE103900222792 /* FayeSubscriptionModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FayeSubscriptionModel.swift; sourceTree = "<group>"; };
-		E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
-		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Starscream.modulemap; sourceTree = "<group>"; };
-		F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Tests.modulemap"; sourceTree = "<group>"; };
-		F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
-		FA96A146A7D76D7C1EEA5F97736E1F0D /* FayeSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-prefix.pch"; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		1DDD99058CD940FD5917CA5AD774B011 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66A658DA4AA077462390CB0E887E48E5 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C3E208C52EE6C8C0689C1B94807309CD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				28E4BFBF9D2ACEADF06BE12B21BDFFBB /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C5F66B163042240ECC70017F4B2423C7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				112044DE1A7A5E8036447F0CC4CA58CB /* Foundation.framework in Frameworks */,
-				A9DB76C98B77BAC9C5FB4172E70966EB /* Starscream.framework in Frameworks */,
-				0D76A5AF0D4781BFAC4D92B66E3A30B4 /* SwiftyJSON.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E307332C7150A001B3765B245D2D6839 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */,
-				0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */ = {
-			isa = PBXGroup;
-			children = (
-				154C747E02B1DCBD4885645B5878477F /* Info.plist */,
-				F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */,
-				2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */,
-				15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */,
-				1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */,
-				E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */,
-				B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */,
-				10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */,
-				D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */,
-				4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */,
-			);
-			name = "Pods-FayeSwift_Tests";
-			path = "Target Support Files/Pods-FayeSwift_Tests";
-			sourceTree = "<group>";
-		};
-		0C03422930E80D7BB92C5C859589F09F /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */,
-				48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */,
-				9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */,
-				4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				6FE6036891606B3E61FED4812F318F99 /* FayeSwift */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */ = {
-			isa = PBXGroup;
-			children = (
-				0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */,
-				9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */,
-			);
-			path = SwiftyJSON;
-			sourceTree = "<group>";
-		};
-		4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		539B253953115DAEA00D55C65474A1F6 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */,
-				D5766AF31CCE103900222792 /* FayeSubscriptionModel.swift */,
-				A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */,
-				B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */,
-				F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */,
-				BA68C21BEA9C15F85E840F5BCD06B262 /* Transport.swift */,
-				2FDDE3F7149F856AAB928833D5658DB3 /* WebsocketTransport.swift */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		57072CFE2F97B4E7645A18D9267BA425 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CFB3E404A66EE13E14582416D200A72C /* Info.plist */,
-				ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */,
-				47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */,
-				18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */,
-				47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */,
-				D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Starscream";
-			sourceTree = "<group>";
-		};
-		6FE6036891606B3E61FED4812F318F99 /* FayeSwift */ = {
-			isa = PBXGroup;
-			children = (
-				539B253953115DAEA00D55C65474A1F6 /* Sources */,
-				DC2BFC3D7A2C4C8331A638C7C1007D20 /* Support Files */,
-			);
-			name = FayeSwift;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		7DB346D0F39D3F0E887471402A8071AB = {
-			isa = PBXGroup;
-			children = (
-				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
-				1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */,
-				0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */,
-				0C03422930E80D7BB92C5C859589F09F /* Pods */,
-				9A590701475CDEC7488348815ADACCBC /* Products */,
-				000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		9A590701475CDEC7488348815ADACCBC /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */,
-				64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */,
-				293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */,
-				9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */,
-				B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E6671F9532A947F40918CF9A0D44F70F /* Info.plist */,
-				2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */,
-				1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */,
-				6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */,
-				0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */,
-				6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftyJSON";
-			sourceTree = "<group>";
-		};
-		AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */ = {
-			isa = PBXGroup;
-			children = (
-				6E1FB52B709CB783F4109CA61174C28B /* Info.plist */,
-				37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */,
-				4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */,
-				B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */,
-				2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */,
-				14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */,
-				4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */,
-				06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */,
-				B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */,
-				2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */,
-			);
-			name = "Pods-FayeSwift_Example";
-			path = "Target Support Files/Pods-FayeSwift_Example";
-			sourceTree = "<group>";
-		};
-		B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */ = {
-			isa = PBXGroup;
-			children = (
-				38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */,
-				87D64F48FA18233694918281C87E0266 /* WebSocket.swift */,
-				57072CFE2F97B4E7645A18D9267BA425 /* Support Files */,
-			);
-			path = Starscream;
-			sourceTree = "<group>";
-		};
-		DC2BFC3D7A2C4C8331A638C7C1007D20 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				2A8281B38766D2C9957F19E11DA20796 /* FayeSwift.modulemap */,
-				8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */,
-				D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */,
-				FA96A146A7D76D7C1EEA5F97736E1F0D /* FayeSwift-prefix.pch */,
-				3928AADA2DE31A1110577AFF292046A8 /* FayeSwift-umbrella.h */,
-				77F9AA324F09A90FB80ECB48C4E4BA1A /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/FayeSwift";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5744E51CF8ECA084D92426D57DC945EF /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4F6AB79FA2ADEC11423A3782E26DC919 /* FayeSwift-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9361BD7539E0A621237603846E00D81E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F1C91701EDE25A8DF650080551A1EE5F /* Starscream-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DA4D3B670D373E4D9F2C0E061EF8C589 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1D9F765D7226F81517EEACB2B6EE02D6 /* SwiftyJSON-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 6A4FCAF5C9B5FE17B150653EFC153B3C /* Build configuration list for PBXNativeTarget "Starscream" */;
-			buildPhases = (
-				6F6B01E4869FC29404539D1F7EA47967 /* Sources */,
-				C3E208C52EE6C8C0689C1B94807309CD /* Frameworks */,
-				9361BD7539E0A621237603846E00D81E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Starscream;
-			productName = Starscream;
-			productReference = 9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */;
-			buildPhases = (
-				F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */,
-				1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */,
-				74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */,
-				396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */,
-				743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */,
-			);
-			name = "Pods-FayeSwift_Tests";
-			productName = "Pods-FayeSwift_Tests";
-			productReference = 293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = EE4323D789F482019F76D08873013AC9 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
-			buildPhases = (
-				5E2995BA89319C883FC5F6B5525881A2 /* Sources */,
-				1DDD99058CD940FD5917CA5AD774B011 /* Frameworks */,
-				DA4D3B670D373E4D9F2C0E061EF8C589 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftyJSON;
-			productName = SwiftyJSON;
-			productReference = B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5B81CC02BA5C8A6F2E0D126266A157A1 /* Build configuration list for PBXNativeTarget "FayeSwift" */;
-			buildPhases = (
-				EB11F02CBEFF194F4C17D9EFC26470D6 /* Sources */,
-				C5F66B163042240ECC70017F4B2423C7 /* Frameworks */,
-				5744E51CF8ECA084D92426D57DC945EF /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				334521CDCF3F9A42442BD9C944494648 /* PBXTargetDependency */,
-				97A4D1CD8C418326C4A40D8446A9BAC8 /* PBXTargetDependency */,
-			);
-			name = FayeSwift;
-			productName = FayeSwift;
-			productReference = B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */;
-			buildPhases = (
-				5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */,
-				E307332C7150A001B3765B245D2D6839 /* Frameworks */,
-				22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */,
-				344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */,
-				5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */,
-			);
-			name = "Pods-FayeSwift_Example";
-			productName = "Pods-FayeSwift_Example";
-			productReference = 64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0730;
-			};
-			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 9A590701475CDEC7488348815ADACCBC /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */,
-				B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */,
-				259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */,
-				0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */,
-				72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5E2995BA89319C883FC5F6B5525881A2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F8555866B482E99822581ABC579F3CD5 /* SwiftyJSON-dummy.m in Sources */,
-				7B376196BBC05D9BB79CB4D466E47F1A /* SwiftyJSON.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6F6B01E4869FC29404539D1F7EA47967 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5B06E0872ABFC40563F3AA7BC14A699F /* SSLSecurity.swift in Sources */,
-				C5681A6362FFDCE2DECBDEE5BFBC907C /* Starscream-dummy.m in Sources */,
-				E5F282A8CE41FC1844203FB427A39226 /* WebSocket.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EB11F02CBEFF194F4C17D9EFC26470D6 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				172D87FC5B15E2E05E643DD1188F953D /* FayeClient.swift in Sources */,
-				D5766AF41CCE103900222792 /* FayeSubscriptionModel.swift in Sources */,
-				71A71AB65AF6D4590B241277504532F1 /* FayeClientDelegate.swift in Sources */,
-				FF0CA1F99F12CC1A9B852F6601921D99 /* FayeSwift-dummy.m in Sources */,
-				A07DDD4070D07F0518CC9913F4C9E2D6 /* NSError+Helper.swift in Sources */,
-				5205B3C8BA6B671C4778F40FFC7FA2AC /* StringExtensions.swift in Sources */,
-				70D1C0428C900D6671409303C06593E3 /* Transport.swift in Sources */,
-				F465C9735101FE983DA25543F4066F9A /* WebsocketTransport.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FayeSwift;
-			target = A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */;
-			targetProxy = 6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */;
-		};
-		334521CDCF3F9A42442BD9C944494648 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = 0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */;
-			targetProxy = 002C971AF7CA74392977401F3B5915E3 /* PBXContainerItemProxy */;
-		};
-		344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = 0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */;
-			targetProxy = 85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */;
-		};
-		396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = 0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */;
-			targetProxy = 252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */;
-		};
-		48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FayeSwift;
-			target = A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */;
-			targetProxy = B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */;
-		};
-		5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = 72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */;
-			targetProxy = E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */;
-		};
-		743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = 72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */;
-			targetProxy = A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */;
-		};
-		97A4D1CD8C418326C4A40D8446A9BAC8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = 72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */;
-			targetProxy = 3BD0A2C746E213094BBD1A609EE7575F /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		2B196DA7A8C6F18B3AB9B0D2CA7C570E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Starscream;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		6C0CE301D9536F43B5C8E08E16712E38 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Pods_FayeSwift_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Pods_FayeSwift_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				ONLY_ACTIVE_ARCH = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Debug;
-		};
-		AAE3D93BCF9437209130DA54E4664DD3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Starscream;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		BA99F75B86D32E8C1D12F5167359D6E2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Pods_FayeSwift_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		BB8D9E76FCCFA23D18222577B77988FB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		BCCAAFB3C077A4CC7BD755B218914AF6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = FayeSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		C05B711322CA076AB9A57512649A029E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Pods_FayeSwift_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		CB53D08DB5954932A4741A1969F2C195 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		D529A91B72E7AAA62AEB5E5A0E3A7114 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = FayeSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C05B711322CA076AB9A57512649A029E /* Debug */,
-				6C0CE301D9536F43B5C8E08E16712E38 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
-				FB45FFD90572718D82AB9092B750F0CA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		5B81CC02BA5C8A6F2E0D126266A157A1 /* Build configuration list for PBXNativeTarget "FayeSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D529A91B72E7AAA62AEB5E5A0E3A7114 /* Debug */,
-				BCCAAFB3C077A4CC7BD755B218914AF6 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		6A4FCAF5C9B5FE17B150653EFC153B3C /* Build configuration list for PBXNativeTarget "Starscream" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				2B196DA7A8C6F18B3AB9B0D2CA7C570E /* Debug */,
-				AAE3D93BCF9437209130DA54E4664DD3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */,
-				BA99F75B86D32E8C1D12F5167359D6E2 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		EE4323D789F482019F76D08873013AC9 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BB8D9E76FCCFA23D18222577B77988FB /* Debug */,
-				CB53D08DB5954932A4741A1969F2C195 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>000A61D7F0D0221F20F470656F297E70</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>AEC58E9B2FE610C5D55CBB2FA4D34F2A</string>
+				<string>0A3C1A1DE210D08A1510BD9669BDF551</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Targets Support Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>050F3648989E5C1D6979F7A0EDAA352A</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>target</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>targetProxy</key>
+			<string>6CF3F2DD66CD874F21BF38ED13DD0295</string>
+		</dict>
+		<key>06B16C30B7CF62C246F4DD2B6BA325D2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0813DA1F91E6465D940389B245DB41E4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>SwiftyJSON.swift</string>
+			<key>path</key>
+			<string>Source/SwiftyJSON.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>08C9E34BFE3CE6E33FB4863BF08E5C1B</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>5EA65666CE5344D192D5B67A85CAFA39</string>
+				<string>D5A61BB662B60E80642A24E32724275E</string>
+				<string>548BDBC634056C39A523C64AB1870D93</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0A3C1A1DE210D08A1510BD9669BDF551</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>154C747E02B1DCBD4885645B5878477F</string>
+				<string>F3FCAA0DF279AAE5F2E8878F0749DD44</string>
+				<string>2D4EF06156597B9C0C9800347C3343FC</string>
+				<string>15765D47A6F3AC9E1A1D641D8B2ADB93</string>
+				<string>1DCE2224000629085D044E4A5FDB2710</string>
+				<string>E4E07C18061452192A8755C57422BE93</string>
+				<string>B9BD316B84610E564DEC11C4F736BD36</string>
+				<string>10E4A21EDDC41F94B30C17F38403E413</string>
+				<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
+				<string>4AB2D41C9043F185BD735AC2476F72C6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-FayeSwift_Tests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0A3C59C66401164839B33852471AF8AF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>0AC47F7781401C3893E4D44D51617586</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>18B303F193AF762CF2DBE56F6B24B5CE</string>
+				<string>957ADEE6257BB32E03F9E872F76D3479</string>
+				<string>704BC00CA3D5CF10EF09C356B799A500</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0AEC95D7E93685709B9C6A5B00BDDEB7</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>3434E7FC44AEA830A2C6B752B26BCE33</string>
+				<string>0BF6F830DDC0BFF42803E165FB1B2621</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>0BF6F830DDC0BFF42803E165FB1B2621</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SwiftyJSON/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>SwiftyJSON</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>0C03422930E80D7BB92C5C859589F09F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B60722EF6A0F9DCD2D7C6D03F8B362CD</string>
+				<string>48BC61B70DBB2FA057A57FF358488F76</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0C93A0CF1060B47E24A8905CE9F33ED1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>5A3750120EFC5FE7B1FF72E6AE18A998</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0DB5BD81DCAEB161F8916282ABFD3340</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
+				<string>9A1314F41D4AF302873CCAE4DF95096E</string>
+				<string>4D7A0A0B35C6A6AD7E9E0865060EEF5F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0E62CB0F51CFEF3EF98705FE6ED1BAA1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>B7098005E3463F71E30EE2ACC3981519</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0F0AD0445D068E37E1C8498A3BF6150D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SwiftyJSON-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>10E4A21EDDC41F94B30C17F38403E413</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>143405C094ED81774A475A1A942BA220</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E83328805FF2933A2C3CEF374AFC4887</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>14B7C4FE824293ABEEF592A7E71C4AFC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>154C747E02B1DCBD4885645B5878477F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>155E3FCDB75DFDBB152E101B4C202295</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>FayeSwift-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>15765D47A6F3AC9E1A1D641D8B2ADB93</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>17665D60312637FC3C2207AEFD337BAD</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>C05B711322CA076AB9A57512649A029E</string>
+				<string>6C0CE301D9536F43B5C8E08E16712E38</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>18B303F193AF762CF2DBE56F6B24B5CE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>18C6718FA411202146721CBD6539BA6A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Starscream-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1DCE2224000629085D044E4A5FDB2710</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1EC0280E5CCCCD96F81E63B562E157DD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>SwiftyJSON.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1F6C69005CE5773E87D416DED050CEA8</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>9E350CCD50346BBEAD007279DA919999</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Development Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1FACCE2E2A3269AA6618DC62E86A5B78</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8128B73B46CE4E130156947FEA792793</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/FayeSwift/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>FayeSwift</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1FFCDC3F1D5C704D66044A14414886F5</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>0A3C59C66401164839B33852471AF8AF</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>22E6B7DDC8DADDE451326034FD9E9C8E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>55B757366E7A17818E9E92058B503641</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>23759C35F6314285C1D642E0F13B2BF3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>10E4A21EDDC41F94B30C17F38403E413</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>252588F94F9C2291A3486B7067E69576</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>259498FBDA923366A8452198A57D1F08</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>9957AD0715343BA2E7013691E1E98F7F</string>
+			<key>buildPhases</key>
+			<array>
+				<string>F2F5FF28F679ADC8A92B329DFCDCE51F</string>
+				<string>1FFCDC3F1D5C704D66044A14414886F5</string>
+				<string>74D6B9A88E9B97B956BF27CEE1DADAC3</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>48D042132AC259FD381EA4D96E17C5B5</string>
+				<string>396DE1C1608FD26AC267D36844C6630E</string>
+				<string>743E721F930E22D28C87A28227016A4E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>productName</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>productReference</key>
+			<string>293CBC63DDF03144B25885047CA44A32</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>2692C5A026D6876DF0B8ED238232F2E6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>284F69195E7B74EADDB82148FD5DC647</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>2901A0000603C63521D4DED64D2B4586</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
+				<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
+				<string>E83328805FF2933A2C3CEF374AFC4887</string>
+				<string>487A65235BC761C63EA749D3504478B5</string>
+				<string>61F102DBDE488931620E8AA49183513B</string>
+				<string>B98F1A78B8406D8DE50340A8632588E9</string>
+				<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Sources</string>
+			<key>path</key>
+			<string>Sources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>293CBC63DDF03144B25885047CA44A32</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods_FayeSwift_Tests.framework</string>
+			<key>path</key>
+			<string>Pods_FayeSwift_Tests.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>2A14E4E75C0921B8190FF7805BDB1994</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftyJSON.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D4EF06156597B9C0C9800347C3343FC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
+				<string>FB45FFD90572718D82AB9092B750F0CA</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>2D9BE4E9101DCFEEF862D023F09073FA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>FayeSwift.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2FE9E957D59ADA0A662E4B8C1A7BD7E2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2FFB5CE6155C8F4095C8976A29498960</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>3EEFF32D5BCC2D64205AA37299BC9746</string>
+			<key>buildPhases</key>
+			<array>
+				<string>08C9E34BFE3CE6E33FB4863BF08E5C1B</string>
+				<string>0E62CB0F51CFEF3EF98705FE6ED1BAA1</string>
+				<string>0C93A0CF1060B47E24A8905CE9F33ED1</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>productName</key>
+			<string>Starscream</string>
+			<key>productReference</key>
+			<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>3434E7FC44AEA830A2C6B752B26BCE33</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SwiftyJSON/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>SwiftyJSON</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>344AD1F5AB3B588C01B21778050F2EAF</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>targetProxy</key>
+			<string>85FD64D2BAA74EAEF9935526FAFB1516</string>
+		</dict>
+		<key>37D9B4C012C932EED434E89C515FA960</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>38A444149F18F886FD0A1E23B45D6671</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>SSLSecurity.swift</string>
+			<key>path</key>
+			<string>Source/SSLSecurity.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>396DE1C1608FD26AC267D36844C6630E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>targetProxy</key>
+			<string>252588F94F9C2291A3486B7067E69576</string>
+		</dict>
+		<key>3E94F4BAAE418F28A0730CC56D7FACFF</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Starscream.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>3EEFF32D5BCC2D64205AA37299BC9746</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>B93968102E7FD3EAE8BED45C989328EF</string>
+				<string>82721887C459F67368E0CF06D91C7E57</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>40CE25E3C0BCCCA4C2AF868C127EE751</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>targetProxy</key>
+			<string>88B85D4B1942F047C1DC470C922B7703</string>
+		</dict>
+		<key>4471A15D81938B6C2CE6A161EC41FEED</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>47C7E36F0C36BF6A9B7F26250E6F35CA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Starscream-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>47C81FB96686C0BE581D0FC3090AFC0D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Starscream.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>487A65235BC761C63EA749D3504478B5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>NSError+Helper.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4885D84AE492246F7B92A35D5F4C2787</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>48BC61B70DBB2FA057A57FF358488F76</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>0813DA1F91E6465D940389B245DB41E4</string>
+				<string>9BE8F84C840D474BB60E62D4A8259C63</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>path</key>
+			<string>SwiftyJSON</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>48D042132AC259FD381EA4D96E17C5B5</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>target</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>targetProxy</key>
+			<string>B1C1530B6651528BC37303CE7401BF99</string>
+		</dict>
+		<key>49EE77FDD417AD6D8551E84B667F057D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>4AB2D41C9043F185BD735AC2476F72C6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4D7A0A0B35C6A6AD7E9E0865060EEF5F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>iOS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5171549988DEFF7760E6073814FFA524</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>548BDBC634056C39A523C64AB1870D93</key>
+		<dict>
+			<key>fileRef</key>
+			<string>87D64F48FA18233694918281C87E0266</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>55B757366E7A17818E9E92058B503641</key>
+		<dict>
+			<key>fileRef</key>
+			<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>57072CFE2F97B4E7645A18D9267BA425</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CFB3E404A66EE13E14582416D200A72C</string>
+				<string>ED0A84AABA966E6DE908E1D84ABB429E</string>
+				<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+				<string>18C6718FA411202146721CBD6539BA6A</string>
+				<string>47C7E36F0C36BF6A9B7F26250E6F35CA</string>
+				<string>D47E6B74B427A4904D75990D1C34E829</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Starscream</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5A3750120EFC5FE7B1FF72E6AE18A998</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D47E6B74B427A4904D75990D1C34E829</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>5CA1401B9C2AC9B84FD288DB6C3FC702</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>84EF024683CD3AA877927D77BAABE64F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>5D1E5C8AB017A941ACA43B001D23BCFA</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>targetProxy</key>
+			<string>E641FD10F82298D81E564BF16487B827</string>
+		</dict>
+		<key>5EA65666CE5344D192D5B67A85CAFA39</key>
+		<dict>
+			<key>fileRef</key>
+			<string>38A444149F18F886FD0A1E23B45D6671</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>61F102DBDE488931620E8AA49183513B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>StringExtensions.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>62E2EDCCDEE8B32C1115DA2D9C6361CC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>WebsocketTransport.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>64F09C054760D010B8E1B3BEB4671267</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods_FayeSwift_Example.framework</string>
+			<key>path</key>
+			<string>Pods_FayeSwift_Example.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>6B923F40E09322629BC57536AFBDAB00</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SwiftyJSON-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6C0CE301D9536F43B5C8E08E16712E38</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>2692C5A026D6876DF0B8ED238232F2E6</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Example</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>6CF3F2DD66CD874F21BF38ED13DD0295</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>remoteInfo</key>
+			<string>FayeSwift</string>
+		</dict>
+		<key>6DCD25231745CBB7A0DE8AE144F32C35</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SwiftyJSON-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6E1FB52B709CB783F4109CA61174C28B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>704BC00CA3D5CF10EF09C356B799A500</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9A1314F41D4AF302873CCAE4DF95096E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>743E721F930E22D28C87A28227016A4E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>targetProxy</key>
+			<string>A1B59F9DF18152F704FE8F577A69E455</string>
+		</dict>
+		<key>74D6B9A88E9B97B956BF27CEE1DADAC3</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>23759C35F6314285C1D642E0F13B2BF3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>786D4D05CB5776378133906FD2A40DE6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B98F1A78B8406D8DE50340A8632588E9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>7B7998CBFC4F64B40662D5BE2471EA16</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6B923F40E09322629BC57536AFBDAB00</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>7DB346D0F39D3F0E887471402A8071AB</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
+				<string>1F6C69005CE5773E87D416DED050CEA8</string>
+				<string>0DB5BD81DCAEB161F8916282ABFD3340</string>
+				<string>0C03422930E80D7BB92C5C859589F09F</string>
+				<string>9A590701475CDEC7488348815ADACCBC</string>
+				<string>000A61D7F0D0221F20F470656F297E70</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7F7A42B67F6F0E9E305772EB90285630</key>
+		<dict>
+			<key>fileRef</key>
+			<string>487A65235BC761C63EA749D3504478B5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>7FCD02EA8C46A7BE4F4C55DF12CEB124</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1FACCE2E2A3269AA6618DC62E86A5B78</string>
+				<string>FB4DED77D2E4800415AEB7F77228E2A1</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>8128B73B46CE4E130156947FEA792793</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>FayeSwift.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>82721887C459F67368E0CF06D91C7E57</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Starscream/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Starscream/Starscream.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>Starscream</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>84EF024683CD3AA877927D77BAABE64F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>85FD64D2BAA74EAEF9935526FAFB1516</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>86074C31635E6527FE9EB5D3D6DE479B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>87D64F48FA18233694918281C87E0266</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>WebSocket.swift</string>
+			<key>path</key>
+			<string>Source/WebSocket.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>88B85D4B1942F047C1DC470C922B7703</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>9228804A5CB29EF1E2D8F805F0EEA281</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Starscream.framework</string>
+			<key>path</key>
+			<string>Starscream.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>957ADEE6257BB32E03F9E872F76D3479</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>968A19F12E6EEAFE1AF4E01F94F08D05</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9957AD0715343BA2E7013691E1E98F7F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>9D3BE8B79BE19FBE664EBECF0B50D300</string>
+				<string>BA99F75B86D32E8C1D12F5167359D6E2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>9A1314F41D4AF302873CCAE4DF95096E</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftyJSON.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9A590701475CDEC7488348815ADACCBC</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
+				<string>64F09C054760D010B8E1B3BEB4671267</string>
+				<string>293CBC63DDF03144B25885047CA44A32</string>
+				<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
+				<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9BE8F84C840D474BB60E62D4A8259C63</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>E6671F9532A947F40918CF9A0D44F70F</string>
+				<string>2A14E4E75C0921B8190FF7805BDB1994</string>
+				<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+				<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
+				<string>0F0AD0445D068E37E1C8498A3BF6150D</string>
+				<string>6B923F40E09322629BC57536AFBDAB00</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/SwiftyJSON</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9D3BE8B79BE19FBE664EBECF0B50D300</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Tests</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>9E350CCD50346BBEAD007279DA919999</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>2901A0000603C63521D4DED64D2B4586</string>
+				<string>DEC84C118AC1DA713A832BFDF21F45E2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>path</key>
+			<string>../..</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9EADFEED37C12003F2FE470649EF5A49</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>E7DD6469E226114253998E809F39BCD1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A16806250A7E7DD443C4EDB15A117D0E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>7B7998CBFC4F64B40662D5BE2471EA16</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A1B59F9DF18152F704FE8F577A69E455</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>A579A389F40ED521DC90FA82DA684595</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FF972453FA7F311A42163A996F627326</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>A96B9484D73AF99585C0F4500550DE5A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>155E3FCDB75DFDBB152E101B4C202295</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AA8A7B051C0D58209033A2F69D3D1CBA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeClientDelegate.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AEC58E9B2FE610C5D55CBB2FA4D34F2A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>6E1FB52B709CB783F4109CA61174C28B</string>
+				<string>37D9B4C012C932EED434E89C515FA960</string>
+				<string>4471A15D81938B6C2CE6A161EC41FEED</string>
+				<string>B29C7FFE8D08A56E77C644C03000FC94</string>
+				<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
+				<string>14B7C4FE824293ABEEF592A7E71C4AFC</string>
+				<string>4885D84AE492246F7B92A35D5F4C2787</string>
+				<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
+				<string>B661AAF1FC01F5B9EB53567F4990C215</string>
+				<string>2692C5A026D6876DF0B8ED238232F2E6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-FayeSwift_Example</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B0F7AB6108413A1758B2F2D999AED350</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>17665D60312637FC3C2207AEFD337BAD</string>
+			<key>buildPhases</key>
+			<array>
+				<string>5CA1401B9C2AC9B84FD288DB6C3FC702</string>
+				<string>E307332C7150A001B3765B245D2D6839</string>
+				<string>22E6B7DDC8DADDE451326034FD9E9C8E</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>050F3648989E5C1D6979F7A0EDAA352A</string>
+				<string>344AD1F5AB3B588C01B21778050F2EAF</string>
+				<string>5D1E5C8AB017A941ACA43B001D23BCFA</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>productName</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>productReference</key>
+			<string>64F09C054760D010B8E1B3BEB4671267</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>B1C1530B6651528BC37303CE7401BF99</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>remoteInfo</key>
+			<string>FayeSwift</string>
+		</dict>
+		<key>B267AB921ABBC8B1A9D9D568D0D05615</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>SwiftyJSON.framework</string>
+			<key>path</key>
+			<string>SwiftyJSON.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>B29C7FFE8D08A56E77C644C03000FC94</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B60722EF6A0F9DCD2D7C6D03F8B362CD</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>38A444149F18F886FD0A1E23B45D6671</string>
+				<string>87D64F48FA18233694918281C87E0266</string>
+				<string>57072CFE2F97B4E7645A18D9267BA425</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>path</key>
+			<string>Starscream</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B661AAF1FC01F5B9EB53567F4990C215</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B67F6FB5E88D459FDF1CC4FD93CB5D6B</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>FayeSwift.framework</string>
+			<key>path</key>
+			<string>FayeSwift.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>B7098005E3463F71E30EE2ACC3981519</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B8D637FB9D47D77BBA1D7A37CE57E05F</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>B93968102E7FD3EAE8BED45C989328EF</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Starscream/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Starscream/Starscream.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>Starscream</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>B98F1A78B8406D8DE50340A8632588E9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>Transport.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B9BD316B84610E564DEC11C4F736BD36</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>name</key>
+			<string>Podfile</string>
+			<key>path</key>
+			<string>../Podfile</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.ruby</string>
+		</dict>
+		<key>BA7367A9809BA19B15229BD6A97BF748</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0813DA1F91E6465D940389B245DB41E4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>BA99F75B86D32E8C1D12F5167359D6E2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>4AB2D41C9043F185BD735AC2476F72C6</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Tests</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>C05B711322CA076AB9A57512649A029E</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>B661AAF1FC01F5B9EB53567F4990C215</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Example</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>C412C36AF79D03E0CB1D365F868D4F0B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeClient.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C56D3FE3F52A8D747E34473EF1315CF7</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>7FCD02EA8C46A7BE4F4C55DF12CEB124</string>
+			<key>buildPhases</key>
+			<array>
+				<string>EC58A33380EA9B37BB944B04C1F3AE53</string>
+				<string>0AC47F7781401C3893E4D44D51617586</string>
+				<string>F912B38D7469867C424F80F4C8770DEB</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>40CE25E3C0BCCCA4C2AF868C127EE751</string>
+				<string>F127B67BA9F6A72ECEF5BAD63C4F3BED</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>productName</key>
+			<string>FayeSwift</string>
+			<key>productReference</key>
+			<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>CFB3E404A66EE13E14582416D200A72C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D26B5E2282A330BE919FE4EFDFB738B3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D41D8CD98F00B204E9800998ECF8427E</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0700</string>
+				<key>LastUpgradeCheck</key>
+				<string>0700</string>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>7DB346D0F39D3F0E887471402A8071AB</string>
+			<key>productRefGroup</key>
+			<string>9A590701475CDEC7488348815ADACCBC</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+				<string>B0F7AB6108413A1758B2F2D999AED350</string>
+				<string>259498FBDA923366A8452198A57D1F08</string>
+				<string>2FFB5CE6155C8F4095C8976A29498960</string>
+				<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			</array>
+		</dict>
+		<key>D47E6B74B427A4904D75990D1C34E829</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Starscream-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D4E1B392E0B7E62D774C23D5F31E2CEC</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>F9256BA24236127F4EA11F8A1F99C6DF</string>
+				<string>BA7367A9809BA19B15229BD6A97BF748</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>D5A61BB662B60E80642A24E32724275E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>18C6718FA411202146721CBD6539BA6A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>D7AD1CA221F811429F2397EA408725EE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1DCE2224000629085D044E4A5FDB2710</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DEC84C118AC1DA713A832BFDF21F45E2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>2D9BE4E9101DCFEEF862D023F09073FA</string>
+				<string>8128B73B46CE4E130156947FEA792793</string>
+				<string>FF972453FA7F311A42163A996F627326</string>
+				<string>EB7D54C397F58433A25DA043B2ED90B3</string>
+				<string>155E3FCDB75DFDBB152E101B4C202295</string>
+				<string>86074C31635E6527FE9EB5D3D6DE479B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>Example/Pods/Target Support Files/FayeSwift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E307332C7150A001B3765B245D2D6839</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>968A19F12E6EEAFE1AF4E01F94F08D05</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>E4E07C18061452192A8755C57422BE93</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E52013BD1A2AEE87A4182D2DEFAD6C4C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>61F102DBDE488931620E8AA49183513B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>E641FD10F82298D81E564BF16487B827</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>E6671F9532A947F40918CF9A0D44F70F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E7DD6469E226114253998E809F39BCD1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>E83328805FF2933A2C3CEF374AFC4887</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeSubscriptionModel.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EB7D54C397F58433A25DA043B2ED90B3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>FayeSwift-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EC58A33380EA9B37BB944B04C1F3AE53</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>49EE77FDD417AD6D8551E84B667F057D</string>
+				<string>284F69195E7B74EADDB82148FD5DC647</string>
+				<string>143405C094ED81774A475A1A942BA220</string>
+				<string>A579A389F40ED521DC90FA82DA684595</string>
+				<string>7F7A42B67F6F0E9E305772EB90285630</string>
+				<string>E52013BD1A2AEE87A4182D2DEFAD6C4C</string>
+				<string>786D4D05CB5776378133906FD2A40DE6</string>
+				<string>F2114CECEB4EB16988736CE300F5ADDC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>ED0A84AABA966E6DE908E1D84ABB429E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Starscream.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F01BE1D9270805A4A53EB2B5924A139E</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>0AEC95D7E93685709B9C6A5B00BDDEB7</string>
+			<key>buildPhases</key>
+			<array>
+				<string>D4E1B392E0B7E62D774C23D5F31E2CEC</string>
+				<string>9EADFEED37C12003F2FE470649EF5A49</string>
+				<string>A16806250A7E7DD443C4EDB15A117D0E</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>productName</key>
+			<string>SwiftyJSON</string>
+			<key>productReference</key>
+			<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>F127B67BA9F6A72ECEF5BAD63C4F3BED</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>targetProxy</key>
+			<string>5171549988DEFF7760E6073814FFA524</string>
+		</dict>
+		<key>F2114CECEB4EB16988736CE300F5ADDC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>F2F5FF28F679ADC8A92B329DFCDCE51F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>D7AD1CA221F811429F2397EA408725EE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F3FCAA0DF279AAE5F2E8878F0749DD44</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F912B38D7469867C424F80F4C8770DEB</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>A96B9484D73AF99585C0F4500550DE5A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F9256BA24236127F4EA11F8A1F99C6DF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>FB45FFD90572718D82AB9092B750F0CA</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>RELEASE=1</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>FB4DED77D2E4800415AEB7F77228E2A1</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8128B73B46CE4E130156947FEA792793</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/FayeSwift/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>FayeSwift</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>FF972453FA7F311A42163A996F627326</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>FayeSwift-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>D41D8CD98F00B204E9800998ECF8427E</string>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,2718 +1,1119 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>000A61D7F0D0221F20F470656F297E70</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AEC58E9B2FE610C5D55CBB2FA4D34F2A</string>
-				<string>0A3C1A1DE210D08A1510BD9669BDF551</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>050F3648989E5C1D6979F7A0EDAA352A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>target</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>targetProxy</key>
-			<string>6CF3F2DD66CD874F21BF38ED13DD0295</string>
-		</dict>
-		<key>06B16C30B7CF62C246F4DD2B6BA325D2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0813DA1F91E6465D940389B245DB41E4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SwiftyJSON.swift</string>
-			<key>path</key>
-			<string>Source/SwiftyJSON.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>08C9E34BFE3CE6E33FB4863BF08E5C1B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5EA65666CE5344D192D5B67A85CAFA39</string>
-				<string>D5A61BB662B60E80642A24E32724275E</string>
-				<string>548BDBC634056C39A523C64AB1870D93</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0A3C1A1DE210D08A1510BD9669BDF551</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>154C747E02B1DCBD4885645B5878477F</string>
-				<string>F3FCAA0DF279AAE5F2E8878F0749DD44</string>
-				<string>2D4EF06156597B9C0C9800347C3343FC</string>
-				<string>15765D47A6F3AC9E1A1D641D8B2ADB93</string>
-				<string>1DCE2224000629085D044E4A5FDB2710</string>
-				<string>E4E07C18061452192A8755C57422BE93</string>
-				<string>B9BD316B84610E564DEC11C4F736BD36</string>
-				<string>10E4A21EDDC41F94B30C17F38403E413</string>
-				<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
-				<string>4AB2D41C9043F185BD735AC2476F72C6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-FayeSwift_Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0A3C59C66401164839B33852471AF8AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0AC47F7781401C3893E4D44D51617586</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>18B303F193AF762CF2DBE56F6B24B5CE</string>
-				<string>957ADEE6257BB32E03F9E872F76D3479</string>
-				<string>704BC00CA3D5CF10EF09C356B799A500</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0AEC95D7E93685709B9C6A5B00BDDEB7</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3434E7FC44AEA830A2C6B752B26BCE33</string>
-				<string>0BF6F830DDC0BFF42803E165FB1B2621</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>0BF6F830DDC0BFF42803E165FB1B2621</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/SwiftyJSON/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>SwiftyJSON</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>0C03422930E80D7BB92C5C859589F09F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B60722EF6A0F9DCD2D7C6D03F8B362CD</string>
-				<string>48BC61B70DBB2FA057A57FF358488F76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0C93A0CF1060B47E24A8905CE9F33ED1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5A3750120EFC5FE7B1FF72E6AE18A998</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0DB5BD81DCAEB161F8916282ABFD3340</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
-				<string>9A1314F41D4AF302873CCAE4DF95096E</string>
-				<string>4D7A0A0B35C6A6AD7E9E0865060EEF5F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0E62CB0F51CFEF3EF98705FE6ED1BAA1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>B7098005E3463F71E30EE2ACC3981519</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0F0AD0445D068E37E1C8498A3BF6150D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SwiftyJSON-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>10E4A21EDDC41F94B30C17F38403E413</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>143405C094ED81774A475A1A942BA220</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E83328805FF2933A2C3CEF374AFC4887</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>14B7C4FE824293ABEEF592A7E71C4AFC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>154C747E02B1DCBD4885645B5878477F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>155E3FCDB75DFDBB152E101B4C202295</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>FayeSwift-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15765D47A6F3AC9E1A1D641D8B2ADB93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>17665D60312637FC3C2207AEFD337BAD</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>C05B711322CA076AB9A57512649A029E</string>
-				<string>6C0CE301D9536F43B5C8E08E16712E38</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>18B303F193AF762CF2DBE56F6B24B5CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>18C6718FA411202146721CBD6539BA6A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Starscream-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1DCE2224000629085D044E4A5FDB2710</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1EC0280E5CCCCD96F81E63B562E157DD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>SwiftyJSON.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1F6C69005CE5773E87D416DED050CEA8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9E350CCD50346BBEAD007279DA919999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1FACCE2E2A3269AA6618DC62E86A5B78</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8128B73B46CE4E130156947FEA792793</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/FayeSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>FayeSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>1FFCDC3F1D5C704D66044A14414886F5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0A3C59C66401164839B33852471AF8AF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>22E6B7DDC8DADDE451326034FD9E9C8E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>55B757366E7A17818E9E92058B503641</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>23759C35F6314285C1D642E0F13B2BF3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>10E4A21EDDC41F94B30C17F38403E413</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252588F94F9C2291A3486B7067E69576</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>259498FBDA923366A8452198A57D1F08</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>9957AD0715343BA2E7013691E1E98F7F</string>
-			<key>buildPhases</key>
-			<array>
-				<string>F2F5FF28F679ADC8A92B329DFCDCE51F</string>
-				<string>1FFCDC3F1D5C704D66044A14414886F5</string>
-				<string>74D6B9A88E9B97B956BF27CEE1DADAC3</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>48D042132AC259FD381EA4D96E17C5B5</string>
-				<string>396DE1C1608FD26AC267D36844C6630E</string>
-				<string>743E721F930E22D28C87A28227016A4E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>productName</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>productReference</key>
-			<string>293CBC63DDF03144B25885047CA44A32</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>2692C5A026D6876DF0B8ED238232F2E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>284F69195E7B74EADDB82148FD5DC647</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>2901A0000603C63521D4DED64D2B4586</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
-				<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
-				<string>E83328805FF2933A2C3CEF374AFC4887</string>
-				<string>487A65235BC761C63EA749D3504478B5</string>
-				<string>61F102DBDE488931620E8AA49183513B</string>
-				<string>B98F1A78B8406D8DE50340A8632588E9</string>
-				<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>path</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>293CBC63DDF03144B25885047CA44A32</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_FayeSwift_Tests.framework</string>
-			<key>path</key>
-			<string>Pods_FayeSwift_Tests.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2A14E4E75C0921B8190FF7805BDB1994</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>SwiftyJSON.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2D4EF06156597B9C0C9800347C3343FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
-				<string>FB45FFD90572718D82AB9092B750F0CA</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2D9BE4E9101DCFEEF862D023F09073FA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>FayeSwift.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2FE9E957D59ADA0A662E4B8C1A7BD7E2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2FFB5CE6155C8F4095C8976A29498960</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>3EEFF32D5BCC2D64205AA37299BC9746</string>
-			<key>buildPhases</key>
-			<array>
-				<string>08C9E34BFE3CE6E33FB4863BF08E5C1B</string>
-				<string>0E62CB0F51CFEF3EF98705FE6ED1BAA1</string>
-				<string>0C93A0CF1060B47E24A8905CE9F33ED1</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>productName</key>
-			<string>Starscream</string>
-			<key>productReference</key>
-			<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>3434E7FC44AEA830A2C6B752B26BCE33</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/SwiftyJSON/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>SwiftyJSON</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>344AD1F5AB3B588C01B21778050F2EAF</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>targetProxy</key>
-			<string>85FD64D2BAA74EAEF9935526FAFB1516</string>
-		</dict>
-		<key>37D9B4C012C932EED434E89C515FA960</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>38A444149F18F886FD0A1E23B45D6671</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SSLSecurity.swift</string>
-			<key>path</key>
-			<string>Source/SSLSecurity.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>396DE1C1608FD26AC267D36844C6630E</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>targetProxy</key>
-			<string>252588F94F9C2291A3486B7067E69576</string>
-		</dict>
-		<key>3E94F4BAAE418F28A0730CC56D7FACFF</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Starscream.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>3EEFF32D5BCC2D64205AA37299BC9746</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>B93968102E7FD3EAE8BED45C989328EF</string>
-				<string>82721887C459F67368E0CF06D91C7E57</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>40CE25E3C0BCCCA4C2AF868C127EE751</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>targetProxy</key>
-			<string>88B85D4B1942F047C1DC470C922B7703</string>
-		</dict>
-		<key>4471A15D81938B6C2CE6A161EC41FEED</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>47C7E36F0C36BF6A9B7F26250E6F35CA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Starscream-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>47C81FB96686C0BE581D0FC3090AFC0D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Starscream.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>487A65235BC761C63EA749D3504478B5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>NSError+Helper.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4885D84AE492246F7B92A35D5F4C2787</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>48BC61B70DBB2FA057A57FF358488F76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0813DA1F91E6465D940389B245DB41E4</string>
-				<string>9BE8F84C840D474BB60E62D4A8259C63</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>path</key>
-			<string>SwiftyJSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>48D042132AC259FD381EA4D96E17C5B5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>target</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>targetProxy</key>
-			<string>B1C1530B6651528BC37303CE7401BF99</string>
-		</dict>
-		<key>49EE77FDD417AD6D8551E84B667F057D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>4AB2D41C9043F185BD735AC2476F72C6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4D7A0A0B35C6A6AD7E9E0865060EEF5F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5171549988DEFF7760E6073814FFA524</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>548BDBC634056C39A523C64AB1870D93</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87D64F48FA18233694918281C87E0266</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>55B757366E7A17818E9E92058B503641</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>57072CFE2F97B4E7645A18D9267BA425</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CFB3E404A66EE13E14582416D200A72C</string>
-				<string>ED0A84AABA966E6DE908E1D84ABB429E</string>
-				<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-				<string>18C6718FA411202146721CBD6539BA6A</string>
-				<string>47C7E36F0C36BF6A9B7F26250E6F35CA</string>
-				<string>D47E6B74B427A4904D75990D1C34E829</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Starscream</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5A3750120EFC5FE7B1FF72E6AE18A998</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D47E6B74B427A4904D75990D1C34E829</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>5CA1401B9C2AC9B84FD288DB6C3FC702</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>84EF024683CD3AA877927D77BAABE64F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>5D1E5C8AB017A941ACA43B001D23BCFA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>targetProxy</key>
-			<string>E641FD10F82298D81E564BF16487B827</string>
-		</dict>
-		<key>5EA65666CE5344D192D5B67A85CAFA39</key>
-		<dict>
-			<key>fileRef</key>
-			<string>38A444149F18F886FD0A1E23B45D6671</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>61F102DBDE488931620E8AA49183513B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>StringExtensions.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>62E2EDCCDEE8B32C1115DA2D9C6361CC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>WebsocketTransport.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>64F09C054760D010B8E1B3BEB4671267</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_FayeSwift_Example.framework</string>
-			<key>path</key>
-			<string>Pods_FayeSwift_Example.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>6B923F40E09322629BC57536AFBDAB00</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SwiftyJSON-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6C0CE301D9536F43B5C8E08E16712E38</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>2692C5A026D6876DF0B8ED238232F2E6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Example</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6CF3F2DD66CD874F21BF38ED13DD0295</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>remoteInfo</key>
-			<string>FayeSwift</string>
-		</dict>
-		<key>6DCD25231745CBB7A0DE8AE144F32C35</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SwiftyJSON-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6E1FB52B709CB783F4109CA61174C28B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>704BC00CA3D5CF10EF09C356B799A500</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9A1314F41D4AF302873CCAE4DF95096E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>743E721F930E22D28C87A28227016A4E</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>targetProxy</key>
-			<string>A1B59F9DF18152F704FE8F577A69E455</string>
-		</dict>
-		<key>74D6B9A88E9B97B956BF27CEE1DADAC3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>23759C35F6314285C1D642E0F13B2BF3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>786D4D05CB5776378133906FD2A40DE6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B98F1A78B8406D8DE50340A8632588E9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>7B7998CBFC4F64B40662D5BE2471EA16</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6B923F40E09322629BC57536AFBDAB00</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>7DB346D0F39D3F0E887471402A8071AB</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
-				<string>1F6C69005CE5773E87D416DED050CEA8</string>
-				<string>0DB5BD81DCAEB161F8916282ABFD3340</string>
-				<string>0C03422930E80D7BB92C5C859589F09F</string>
-				<string>9A590701475CDEC7488348815ADACCBC</string>
-				<string>000A61D7F0D0221F20F470656F297E70</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7F7A42B67F6F0E9E305772EB90285630</key>
-		<dict>
-			<key>fileRef</key>
-			<string>487A65235BC761C63EA749D3504478B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>7FCD02EA8C46A7BE4F4C55DF12CEB124</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>1FACCE2E2A3269AA6618DC62E86A5B78</string>
-				<string>FB4DED77D2E4800415AEB7F77228E2A1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>8128B73B46CE4E130156947FEA792793</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>FayeSwift.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>82721887C459F67368E0CF06D91C7E57</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Starscream/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Starscream/Starscream.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>Starscream</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>84EF024683CD3AA877927D77BAABE64F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>85FD64D2BAA74EAEF9935526FAFB1516</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>86074C31635E6527FE9EB5D3D6DE479B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>87D64F48FA18233694918281C87E0266</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>WebSocket.swift</string>
-			<key>path</key>
-			<string>Source/WebSocket.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>88B85D4B1942F047C1DC470C922B7703</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>9228804A5CB29EF1E2D8F805F0EEA281</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Starscream.framework</string>
-			<key>path</key>
-			<string>Starscream.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>957ADEE6257BB32E03F9E872F76D3479</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>968A19F12E6EEAFE1AF4E01F94F08D05</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957AD0715343BA2E7013691E1E98F7F</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>9D3BE8B79BE19FBE664EBECF0B50D300</string>
-				<string>BA99F75B86D32E8C1D12F5167359D6E2</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>9A1314F41D4AF302873CCAE4DF95096E</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>SwiftyJSON.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>9A590701475CDEC7488348815ADACCBC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
-				<string>64F09C054760D010B8E1B3BEB4671267</string>
-				<string>293CBC63DDF03144B25885047CA44A32</string>
-				<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
-				<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9BE8F84C840D474BB60E62D4A8259C63</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E6671F9532A947F40918CF9A0D44F70F</string>
-				<string>2A14E4E75C0921B8190FF7805BDB1994</string>
-				<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-				<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
-				<string>0F0AD0445D068E37E1C8498A3BF6150D</string>
-				<string>6B923F40E09322629BC57536AFBDAB00</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/SwiftyJSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D3BE8B79BE19FBE664EBECF0B50D300</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Tests</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>9E350CCD50346BBEAD007279DA919999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2901A0000603C63521D4DED64D2B4586</string>
-				<string>DEC84C118AC1DA713A832BFDF21F45E2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9EADFEED37C12003F2FE470649EF5A49</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E7DD6469E226114253998E809F39BCD1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>A16806250A7E7DD443C4EDB15A117D0E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>7B7998CBFC4F64B40662D5BE2471EA16</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>A1B59F9DF18152F704FE8F577A69E455</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>A579A389F40ED521DC90FA82DA684595</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FF972453FA7F311A42163A996F627326</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>A96B9484D73AF99585C0F4500550DE5A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>155E3FCDB75DFDBB152E101B4C202295</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>AA8A7B051C0D58209033A2F69D3D1CBA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeClientDelegate.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEC58E9B2FE610C5D55CBB2FA4D34F2A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6E1FB52B709CB783F4109CA61174C28B</string>
-				<string>37D9B4C012C932EED434E89C515FA960</string>
-				<string>4471A15D81938B6C2CE6A161EC41FEED</string>
-				<string>B29C7FFE8D08A56E77C644C03000FC94</string>
-				<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
-				<string>14B7C4FE824293ABEEF592A7E71C4AFC</string>
-				<string>4885D84AE492246F7B92A35D5F4C2787</string>
-				<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
-				<string>B661AAF1FC01F5B9EB53567F4990C215</string>
-				<string>2692C5A026D6876DF0B8ED238232F2E6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-FayeSwift_Example</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B0F7AB6108413A1758B2F2D999AED350</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>17665D60312637FC3C2207AEFD337BAD</string>
-			<key>buildPhases</key>
-			<array>
-				<string>5CA1401B9C2AC9B84FD288DB6C3FC702</string>
-				<string>E307332C7150A001B3765B245D2D6839</string>
-				<string>22E6B7DDC8DADDE451326034FD9E9C8E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>050F3648989E5C1D6979F7A0EDAA352A</string>
-				<string>344AD1F5AB3B588C01B21778050F2EAF</string>
-				<string>5D1E5C8AB017A941ACA43B001D23BCFA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>productName</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>productReference</key>
-			<string>64F09C054760D010B8E1B3BEB4671267</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>B1C1530B6651528BC37303CE7401BF99</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>remoteInfo</key>
-			<string>FayeSwift</string>
-		</dict>
-		<key>B267AB921ABBC8B1A9D9D568D0D05615</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>SwiftyJSON.framework</string>
-			<key>path</key>
-			<string>SwiftyJSON.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B29C7FFE8D08A56E77C644C03000FC94</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B60722EF6A0F9DCD2D7C6D03F8B362CD</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>38A444149F18F886FD0A1E23B45D6671</string>
-				<string>87D64F48FA18233694918281C87E0266</string>
-				<string>57072CFE2F97B4E7645A18D9267BA425</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>path</key>
-			<string>Starscream</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B661AAF1FC01F5B9EB53567F4990C215</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B67F6FB5E88D459FDF1CC4FD93CB5D6B</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>FayeSwift.framework</string>
-			<key>path</key>
-			<string>FayeSwift.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B7098005E3463F71E30EE2ACC3981519</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B8D637FB9D47D77BBA1D7A37CE57E05F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>B93968102E7FD3EAE8BED45C989328EF</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Starscream/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Starscream/Starscream.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>Starscream</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>B98F1A78B8406D8DE50340A8632588E9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>Transport.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B9BD316B84610E564DEC11C4F736BD36</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>BA7367A9809BA19B15229BD6A97BF748</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0813DA1F91E6465D940389B245DB41E4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>BA99F75B86D32E8C1D12F5167359D6E2</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>4AB2D41C9043F185BD735AC2476F72C6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Tests</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>C05B711322CA076AB9A57512649A029E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>B661AAF1FC01F5B9EB53567F4990C215</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Example</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>C412C36AF79D03E0CB1D365F868D4F0B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeClient.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C56D3FE3F52A8D747E34473EF1315CF7</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>7FCD02EA8C46A7BE4F4C55DF12CEB124</string>
-			<key>buildPhases</key>
-			<array>
-				<string>EC58A33380EA9B37BB944B04C1F3AE53</string>
-				<string>0AC47F7781401C3893E4D44D51617586</string>
-				<string>F912B38D7469867C424F80F4C8770DEB</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>40CE25E3C0BCCCA4C2AF868C127EE751</string>
-				<string>F127B67BA9F6A72ECEF5BAD63C4F3BED</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>productName</key>
-			<string>FayeSwift</string>
-			<key>productReference</key>
-			<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>CFB3E404A66EE13E14582416D200A72C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D26B5E2282A330BE919FE4EFDFB738B3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D41D8CD98F00B204E9800998ECF8427E</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastSwiftUpdateCheck</key>
-				<string>0700</string>
-				<key>LastUpgradeCheck</key>
-				<string>0700</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>7DB346D0F39D3F0E887471402A8071AB</string>
-			<key>productRefGroup</key>
-			<string>9A590701475CDEC7488348815ADACCBC</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-				<string>B0F7AB6108413A1758B2F2D999AED350</string>
-				<string>259498FBDA923366A8452198A57D1F08</string>
-				<string>2FFB5CE6155C8F4095C8976A29498960</string>
-				<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			</array>
-		</dict>
-		<key>D47E6B74B427A4904D75990D1C34E829</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Starscream-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D4E1B392E0B7E62D774C23D5F31E2CEC</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F9256BA24236127F4EA11F8A1F99C6DF</string>
-				<string>BA7367A9809BA19B15229BD6A97BF748</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>D5A61BB662B60E80642A24E32724275E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C6718FA411202146721CBD6539BA6A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D7AD1CA221F811429F2397EA408725EE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1DCE2224000629085D044E4A5FDB2710</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DEC84C118AC1DA713A832BFDF21F45E2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2D9BE4E9101DCFEEF862D023F09073FA</string>
-				<string>8128B73B46CE4E130156947FEA792793</string>
-				<string>FF972453FA7F311A42163A996F627326</string>
-				<string>EB7D54C397F58433A25DA043B2ED90B3</string>
-				<string>155E3FCDB75DFDBB152E101B4C202295</string>
-				<string>86074C31635E6527FE9EB5D3D6DE479B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Example/Pods/Target Support Files/FayeSwift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E307332C7150A001B3765B245D2D6839</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>968A19F12E6EEAFE1AF4E01F94F08D05</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E4E07C18061452192A8755C57422BE93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E52013BD1A2AEE87A4182D2DEFAD6C4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>61F102DBDE488931620E8AA49183513B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>E641FD10F82298D81E564BF16487B827</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>E6671F9532A947F40918CF9A0D44F70F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E7DD6469E226114253998E809F39BCD1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E83328805FF2933A2C3CEF374AFC4887</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeSubscriptionModel.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EB7D54C397F58433A25DA043B2ED90B3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>FayeSwift-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC58A33380EA9B37BB944B04C1F3AE53</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>49EE77FDD417AD6D8551E84B667F057D</string>
-				<string>284F69195E7B74EADDB82148FD5DC647</string>
-				<string>143405C094ED81774A475A1A942BA220</string>
-				<string>A579A389F40ED521DC90FA82DA684595</string>
-				<string>7F7A42B67F6F0E9E305772EB90285630</string>
-				<string>E52013BD1A2AEE87A4182D2DEFAD6C4C</string>
-				<string>786D4D05CB5776378133906FD2A40DE6</string>
-				<string>F2114CECEB4EB16988736CE300F5ADDC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>ED0A84AABA966E6DE908E1D84ABB429E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Starscream.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F01BE1D9270805A4A53EB2B5924A139E</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>0AEC95D7E93685709B9C6A5B00BDDEB7</string>
-			<key>buildPhases</key>
-			<array>
-				<string>D4E1B392E0B7E62D774C23D5F31E2CEC</string>
-				<string>9EADFEED37C12003F2FE470649EF5A49</string>
-				<string>A16806250A7E7DD443C4EDB15A117D0E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>productName</key>
-			<string>SwiftyJSON</string>
-			<key>productReference</key>
-			<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>F127B67BA9F6A72ECEF5BAD63C4F3BED</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>targetProxy</key>
-			<string>5171549988DEFF7760E6073814FFA524</string>
-		</dict>
-		<key>F2114CECEB4EB16988736CE300F5ADDC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>F2F5FF28F679ADC8A92B329DFCDCE51F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>D7AD1CA221F811429F2397EA408725EE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F3FCAA0DF279AAE5F2E8878F0749DD44</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F912B38D7469867C424F80F4C8770DEB</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>A96B9484D73AF99585C0F4500550DE5A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F9256BA24236127F4EA11F8A1F99C6DF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FB45FFD90572718D82AB9092B750F0CA</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>FB4DED77D2E4800415AEB7F77228E2A1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8128B73B46CE4E130156947FEA792793</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/FayeSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>FayeSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>FF972453FA7F311A42163A996F627326</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>FayeSwift-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>D41D8CD98F00B204E9800998ECF8427E</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		143405C094ED81774A475A1A942BA220 /* FayeSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		18B303F193AF762CF2DBE56F6B24B5CE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		284F69195E7B74EADDB82148FD5DC647 /* FayeClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		49EE77FDD417AD6D8551E84B667F057D /* FayeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		548BDBC634056C39A523C64AB1870D93 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A3750120EFC5FE7B1FF72E6AE18A998 /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EA65666CE5344D192D5B67A85CAFA39 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		704BC00CA3D5CF10EF09C356B799A500 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */; };
+		786D4D05CB5776378133906FD2A40DE6 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7B7998CBFC4F64B40662D5BE2471EA16 /* SwiftyJSON-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F7A42B67F6F0E9E305772EB90285630 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */; };
+		957ADEE6257BB32E03F9E872F76D3479 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
+		968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		A579A389F40ED521DC90FA82DA684595 /* FayeSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */; };
+		A96B9484D73AF99585C0F4500550DE5A /* FayeSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B7098005E3463F71E30EE2ACC3981519 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		BA7367A9809BA19B15229BD6A97BF748 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D5A61BB662B60E80642A24E32724275E /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
+		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
+		E52013BD1A2AEE87A4182D2DEFAD6C4C /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E7DD6469E226114253998E809F39BCD1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		F2114CECEB4EB16988736CE300F5ADDC /* WebsocketTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F9256BA24236127F4EA11F8A1F99C6DF /* SwiftyJSON-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
+			remoteInfo = Starscream;
+		};
+		5171549988DEFF7760E6073814FFA524 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
+			remoteInfo = SwiftyJSON;
+		};
+		6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C56D3FE3F52A8D747E34473EF1315CF7;
+			remoteInfo = FayeSwift;
+		};
+		85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
+			remoteInfo = Starscream;
+		};
+		88B85D4B1942F047C1DC470C922B7703 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
+			remoteInfo = Starscream;
+		};
+		A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
+			remoteInfo = SwiftyJSON;
+		};
+		B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C56D3FE3F52A8D747E34473EF1315CF7;
+			remoteInfo = FayeSwift;
+		};
+		E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
+			remoteInfo = SwiftyJSON;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Example-umbrella.h"; sourceTree = "<group>"; };
+		0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
+		0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
+		10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Tests-umbrella.h"; sourceTree = "<group>"; };
+		14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-frameworks.sh"; sourceTree = "<group>"; };
+		154C747E02B1DCBD4885645B5878477F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-umbrella.h"; sourceTree = "<group>"; };
+		15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Starscream-dummy.m"; sourceTree = "<group>"; };
+		1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Tests-dummy.m"; sourceTree = "<group>"; };
+		1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
+		2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
+		293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
+		2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		2D9BE4E9101DCFEEF862D023F09073FA /* FayeSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = FayeSwift.modulemap; sourceTree = "<group>"; };
+		2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Example-dummy.m"; sourceTree = "<group>"; };
+		37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Example.modulemap"; sourceTree = "<group>"; };
+		38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Source/SSLSecurity.swift; sourceTree = "<group>"; };
+		3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-prefix.pch"; sourceTree = "<group>"; };
+		47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.xcconfig; sourceTree = "<group>"; };
+		487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Helper.swift"; sourceTree = "<group>"; };
+		4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-resources.sh"; sourceTree = "<group>"; };
+		4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebsocketTransport.swift; sourceTree = "<group>"; };
+		64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
+		6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftyJSON-dummy.m"; sourceTree = "<group>"; };
+		6E1FB52B709CB783F4109CA61174C28B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FayeSwift.xcconfig; sourceTree = "<group>"; };
+		86074C31635E6527FE9EB5D3D6DE479B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		87D64F48FA18233694918281C87E0266 /* WebSocket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Source/WebSocket.swift; sourceTree = "<group>"; };
+		9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClientDelegate.swift; sourceTree = "<group>"; };
+		B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FayeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-resources.sh"; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
+		CFB3E404A66EE13E14582416D200A72C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
+		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeSubscriptionModel.swift; sourceTree = "<group>"; };
+		EB7D54C397F58433A25DA043B2ED90B3 /* FayeSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-prefix.pch"; sourceTree = "<group>"; };
+		ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Starscream.modulemap; sourceTree = "<group>"; };
+		F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Tests.modulemap"; sourceTree = "<group>"; };
+		FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0AC47F7781401C3893E4D44D51617586 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				18B303F193AF762CF2DBE56F6B24B5CE /* Foundation.framework in Frameworks */,
+				957ADEE6257BB32E03F9E872F76D3479 /* Starscream.framework in Frameworks */,
+				704BC00CA3D5CF10EF09C356B799A500 /* SwiftyJSON.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0E62CB0F51CFEF3EF98705FE6ED1BAA1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B7098005E3463F71E30EE2ACC3981519 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EADFEED37C12003F2FE470649EF5A49 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7DD6469E226114253998E809F39BCD1 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E307332C7150A001B3765B245D2D6839 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */,
+				0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				154C747E02B1DCBD4885645B5878477F /* Info.plist */,
+				F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */,
+				2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */,
+				15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */,
+				1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */,
+				E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */,
+				B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */,
+				10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */,
+				D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */,
+				4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */,
+			);
+			name = "Pods-FayeSwift_Tests";
+			path = "Target Support Files/Pods-FayeSwift_Tests";
+			sourceTree = "<group>";
+		};
+		0C03422930E80D7BB92C5C859589F09F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */,
+				48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */,
+				9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */,
+				4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9E350CCD50346BBEAD007279DA919999 /* FayeSwift */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		2901A0000603C63521D4DED64D2B4586 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				D59521FF1D2E5F8300BB1F1B /* client */,
+				D59521FC1D2E5F6300BB1F1B /* model */,
+				D59521FD1D2E5F6900BB1F1B /* helper */,
+				D59521FE1D2E5F7400BB1F1B /* transport */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */ = {
+			isa = PBXGroup;
+			children = (
+				0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */,
+				9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */,
+			);
+			path = SwiftyJSON;
+			sourceTree = "<group>";
+		};
+		4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		57072CFE2F97B4E7645A18D9267BA425 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				CFB3E404A66EE13E14582416D200A72C /* Info.plist */,
+				ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */,
+				47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */,
+				18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */,
+				47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */,
+				D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Starscream";
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */,
+				0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */,
+				0C03422930E80D7BB92C5C859589F09F /* Pods */,
+				9A590701475CDEC7488348815ADACCBC /* Products */,
+				000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		9A590701475CDEC7488348815ADACCBC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */,
+				64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */,
+				293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */,
+				9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */,
+				B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E6671F9532A947F40918CF9A0D44F70F /* Info.plist */,
+				2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */,
+				1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */,
+				6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */,
+				0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */,
+				6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/SwiftyJSON";
+			sourceTree = "<group>";
+		};
+		9E350CCD50346BBEAD007279DA919999 /* FayeSwift */ = {
+			isa = PBXGroup;
+			children = (
+				2901A0000603C63521D4DED64D2B4586 /* Sources */,
+				DEC84C118AC1DA713A832BFDF21F45E2 /* Support Files */,
+			);
+			name = FayeSwift;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */ = {
+			isa = PBXGroup;
+			children = (
+				6E1FB52B709CB783F4109CA61174C28B /* Info.plist */,
+				37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */,
+				4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */,
+				B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */,
+				2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */,
+				14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */,
+				4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */,
+				06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */,
+				B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */,
+				2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */,
+			);
+			name = "Pods-FayeSwift_Example";
+			path = "Target Support Files/Pods-FayeSwift_Example";
+			sourceTree = "<group>";
+		};
+		B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */ = {
+			isa = PBXGroup;
+			children = (
+				38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */,
+				87D64F48FA18233694918281C87E0266 /* WebSocket.swift */,
+				57072CFE2F97B4E7645A18D9267BA425 /* Support Files */,
+			);
+			path = Starscream;
+			sourceTree = "<group>";
+		};
+		D59521FC1D2E5F6300BB1F1B /* model */ = {
+			isa = PBXGroup;
+			children = (
+				E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */,
+			);
+			name = model;
+			sourceTree = "<group>";
+		};
+		D59521FD1D2E5F6900BB1F1B /* helper */ = {
+			isa = PBXGroup;
+			children = (
+				487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */,
+				61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */,
+			);
+			name = helper;
+			sourceTree = "<group>";
+		};
+		D59521FE1D2E5F7400BB1F1B /* transport */ = {
+			isa = PBXGroup;
+			children = (
+				B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */,
+				62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */,
+			);
+			name = transport;
+			sourceTree = "<group>";
+		};
+		D59521FF1D2E5F8300BB1F1B /* client */ = {
+			isa = PBXGroup;
+			children = (
+				C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */,
+				AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */,
+			);
+			name = client;
+			sourceTree = "<group>";
+		};
+		DEC84C118AC1DA713A832BFDF21F45E2 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				2D9BE4E9101DCFEEF862D023F09073FA /* FayeSwift.modulemap */,
+				8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */,
+				FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */,
+				EB7D54C397F58433A25DA043B2ED90B3 /* FayeSwift-prefix.pch */,
+				155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */,
+				86074C31635E6527FE9EB5D3D6DE479B /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/FayeSwift";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0C93A0CF1060B47E24A8905CE9F33ED1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5A3750120EFC5FE7B1FF72E6AE18A998 /* Starscream-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A16806250A7E7DD443C4EDB15A117D0E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7B7998CBFC4F64B40662D5BE2471EA16 /* SwiftyJSON-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F912B38D7469867C424F80F4C8770DEB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A96B9484D73AF99585C0F4500550DE5A /* FayeSwift-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */;
+			buildPhases = (
+				F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */,
+				1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */,
+				74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */,
+				396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */,
+				743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */,
+			);
+			name = "Pods-FayeSwift_Tests";
+			productName = "Pods-FayeSwift_Tests";
+			productReference = 293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2FFB5CE6155C8F4095C8976A29498960 /* Starscream */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EEFF32D5BCC2D64205AA37299BC9746 /* Build configuration list for PBXNativeTarget "Starscream" */;
+			buildPhases = (
+				08C9E34BFE3CE6E33FB4863BF08E5C1B /* Sources */,
+				0E62CB0F51CFEF3EF98705FE6ED1BAA1 /* Frameworks */,
+				0C93A0CF1060B47E24A8905CE9F33ED1 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Starscream;
+			productName = Starscream;
+			productReference = 9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */;
+			buildPhases = (
+				5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */,
+				E307332C7150A001B3765B245D2D6839 /* Frameworks */,
+				22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */,
+				344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */,
+				5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */,
+			);
+			name = "Pods-FayeSwift_Example";
+			productName = "Pods-FayeSwift_Example";
+			productReference = 64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7FCD02EA8C46A7BE4F4C55DF12CEB124 /* Build configuration list for PBXNativeTarget "FayeSwift" */;
+			buildPhases = (
+				EC58A33380EA9B37BB944B04C1F3AE53 /* Sources */,
+				0AC47F7781401C3893E4D44D51617586 /* Frameworks */,
+				F912B38D7469867C424F80F4C8770DEB /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				40CE25E3C0BCCCA4C2AF868C127EE751 /* PBXTargetDependency */,
+				F127B67BA9F6A72ECEF5BAD63C4F3BED /* PBXTargetDependency */,
+			);
+			name = FayeSwift;
+			productName = FayeSwift;
+			productReference = B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0AEC95D7E93685709B9C6A5B00BDDEB7 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
+			buildPhases = (
+				D4E1B392E0B7E62D774C23D5F31E2CEC /* Sources */,
+				9EADFEED37C12003F2FE470649EF5A49 /* Frameworks */,
+				A16806250A7E7DD443C4EDB15A117D0E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftyJSON;
+			productName = SwiftyJSON;
+			productReference = B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
+			};
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 9A590701475CDEC7488348815ADACCBC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */,
+				B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */,
+				259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */,
+				2FFB5CE6155C8F4095C8976A29498960 /* Starscream */,
+				F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		08C9E34BFE3CE6E33FB4863BF08E5C1B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5EA65666CE5344D192D5B67A85CAFA39 /* SSLSecurity.swift in Sources */,
+				D5A61BB662B60E80642A24E32724275E /* Starscream-dummy.m in Sources */,
+				548BDBC634056C39A523C64AB1870D93 /* WebSocket.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D4E1B392E0B7E62D774C23D5F31E2CEC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F9256BA24236127F4EA11F8A1F99C6DF /* SwiftyJSON-dummy.m in Sources */,
+				BA7367A9809BA19B15229BD6A97BF748 /* SwiftyJSON.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC58A33380EA9B37BB944B04C1F3AE53 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49EE77FDD417AD6D8551E84B667F057D /* FayeClient.swift in Sources */,
+				284F69195E7B74EADDB82148FD5DC647 /* FayeClientDelegate.swift in Sources */,
+				143405C094ED81774A475A1A942BA220 /* FayeSubscriptionModel.swift in Sources */,
+				A579A389F40ED521DC90FA82DA684595 /* FayeSwift-dummy.m in Sources */,
+				7F7A42B67F6F0E9E305772EB90285630 /* NSError+Helper.swift in Sources */,
+				E52013BD1A2AEE87A4182D2DEFAD6C4C /* StringExtensions.swift in Sources */,
+				786D4D05CB5776378133906FD2A40DE6 /* Transport.swift in Sources */,
+				F2114CECEB4EB16988736CE300F5ADDC /* WebsocketTransport.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FayeSwift;
+			target = C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */;
+			targetProxy = 6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */;
+		};
+		344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
+			targetProxy = 85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */;
+		};
+		396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
+			targetProxy = 252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */;
+		};
+		40CE25E3C0BCCCA4C2AF868C127EE751 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
+			targetProxy = 88B85D4B1942F047C1DC470C922B7703 /* PBXContainerItemProxy */;
+		};
+		48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FayeSwift;
+			target = C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */;
+			targetProxy = B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */;
+		};
+		5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
+			targetProxy = E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */;
+		};
+		743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
+			targetProxy = A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */;
+		};
+		F127B67BA9F6A72ECEF5BAD63C4F3BED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
+			targetProxy = 5171549988DEFF7760E6073814FFA524 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0BF6F830DDC0BFF42803E165FB1B2621 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1FACCE2E2A3269AA6618DC62E86A5B78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = FayeSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3434E7FC44AEA830A2C6B752B26BCE33 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6C0CE301D9536F43B5C8E08E16712E38 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		82721887C459F67368E0CF06D91C7E57 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Starscream;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		B93968102E7FD3EAE8BED45C989328EF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Starscream;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BA99F75B86D32E8C1D12F5167359D6E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C05B711322CA076AB9A57512649A029E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		FB4DED77D2E4800415AEB7F77228E2A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = FayeSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0AEC95D7E93685709B9C6A5B00BDDEB7 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3434E7FC44AEA830A2C6B752B26BCE33 /* Debug */,
+				0BF6F830DDC0BFF42803E165FB1B2621 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C05B711322CA076AB9A57512649A029E /* Debug */,
+				6C0CE301D9536F43B5C8E08E16712E38 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
+				FB45FFD90572718D82AB9092B750F0CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3EEFF32D5BCC2D64205AA37299BC9746 /* Build configuration list for PBXNativeTarget "Starscream" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B93968102E7FD3EAE8BED45C989328EF /* Debug */,
+				82721887C459F67368E0CF06D91C7E57 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7FCD02EA8C46A7BE4F4C55DF12CEB124 /* Build configuration list for PBXNativeTarget "FayeSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FACCE2E2A3269AA6618DC62E86A5B78 /* Debug */,
+				FB4DED77D2E4800415AEB7F77228E2A1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */,
+				BA99F75B86D32E8C1D12F5167359D6E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+}

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		A07DDD4070D07F0518CC9913F4C9E2D6 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A9DB76C98B77BAC9C5FB4172E70966EB /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
 		C5681A6362FFDCE2DECBDEE5BFBC907C /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
+		D5766AF41CCE103900222792 /* FayeSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5766AF31CCE103900222792 /* FayeSubscriptionModel.swift */; };
 		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
 		E5F282A8CE41FC1844203FB427A39226 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F1C91701EDE25A8DF650080551A1EE5F /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -144,6 +145,7 @@
 		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
 		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
+		D5766AF31CCE103900222792 /* FayeSubscriptionModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FayeSubscriptionModel.swift; sourceTree = "<group>"; };
 		E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
 		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 			isa = PBXGroup;
 			children = (
 				E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */,
+				D5766AF31CCE103900222792 /* FayeSubscriptionModel.swift */,
 				A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */,
 				B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */,
 				F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */,
@@ -589,6 +592,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				172D87FC5B15E2E05E643DD1188F953D /* FayeClient.swift in Sources */,
+				D5766AF41CCE103900222792 /* FayeSubscriptionModel.swift in Sources */,
 				71A71AB65AF6D4590B241277504532F1 /* FayeClientDelegate.swift in Sources */,
 				FF0CA1F99F12CC1A9B852F6601921D99 /* FayeSwift-dummy.m in Sources */,
 				A07DDD4070D07F0518CC9913F4C9E2D6 /* NSError+Helper.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,2691 +1,1094 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>000A61D7F0D0221F20F470656F297E70</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AEC58E9B2FE610C5D55CBB2FA4D34F2A</string>
-				<string>0A3C1A1DE210D08A1510BD9669BDF551</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>002C971AF7CA74392977401F3B5915E3</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>050F3648989E5C1D6979F7A0EDAA352A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>target</key>
-			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
-			<key>targetProxy</key>
-			<string>6CF3F2DD66CD874F21BF38ED13DD0295</string>
-		</dict>
-		<key>06B16C30B7CF62C246F4DD2B6BA325D2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0813DA1F91E6465D940389B245DB41E4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SwiftyJSON.swift</string>
-			<key>path</key>
-			<string>Source/SwiftyJSON.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0A3C1A1DE210D08A1510BD9669BDF551</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>154C747E02B1DCBD4885645B5878477F</string>
-				<string>F3FCAA0DF279AAE5F2E8878F0749DD44</string>
-				<string>2D4EF06156597B9C0C9800347C3343FC</string>
-				<string>15765D47A6F3AC9E1A1D641D8B2ADB93</string>
-				<string>1DCE2224000629085D044E4A5FDB2710</string>
-				<string>E4E07C18061452192A8755C57422BE93</string>
-				<string>B9BD316B84610E564DEC11C4F736BD36</string>
-				<string>10E4A21EDDC41F94B30C17F38403E413</string>
-				<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
-				<string>4AB2D41C9043F185BD735AC2476F72C6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-FayeSwift_Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0A3C59C66401164839B33852471AF8AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0C03422930E80D7BB92C5C859589F09F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B60722EF6A0F9DCD2D7C6D03F8B362CD</string>
-				<string>48BC61B70DBB2FA057A57FF358488F76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0D76A5AF0D4781BFAC4D92B66E3A30B4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9A1314F41D4AF302873CCAE4DF95096E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0DB5BD81DCAEB161F8916282ABFD3340</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
-				<string>9A1314F41D4AF302873CCAE4DF95096E</string>
-				<string>4D7A0A0B35C6A6AD7E9E0865060EEF5F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0F0AD0445D068E37E1C8498A3BF6150D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SwiftyJSON-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0FFB2621535432DEA9289D0F9EEEE26C</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>6A4FCAF5C9B5FE17B150653EFC153B3C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>6F6B01E4869FC29404539D1F7EA47967</string>
-				<string>C3E208C52EE6C8C0689C1B94807309CD</string>
-				<string>9361BD7539E0A621237603846E00D81E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>productName</key>
-			<string>Starscream</string>
-			<key>productReference</key>
-			<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>10E4A21EDDC41F94B30C17F38403E413</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>112044DE1A7A5E8036447F0CC4CA58CB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>14B7C4FE824293ABEEF592A7E71C4AFC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>154C747E02B1DCBD4885645B5878477F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15765D47A6F3AC9E1A1D641D8B2ADB93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>172D87FC5B15E2E05E643DD1188F953D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E09B4B87B5F08505B3484854BDF5F693</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>17665D60312637FC3C2207AEFD337BAD</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>C05B711322CA076AB9A57512649A029E</string>
-				<string>6C0CE301D9536F43B5C8E08E16712E38</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>18C6718FA411202146721CBD6539BA6A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Starscream-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1D9F765D7226F81517EEACB2B6EE02D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6B923F40E09322629BC57536AFBDAB00</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>1DCE2224000629085D044E4A5FDB2710</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1DDD99058CD940FD5917CA5AD774B011</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>66A658DA4AA077462390CB0E887E48E5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1EC0280E5CCCCD96F81E63B562E157DD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>SwiftyJSON.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1F6C69005CE5773E87D416DED050CEA8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6FE6036891606B3E61FED4812F318F99</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1FFCDC3F1D5C704D66044A14414886F5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0A3C59C66401164839B33852471AF8AF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>22E6B7DDC8DADDE451326034FD9E9C8E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>55B757366E7A17818E9E92058B503641</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>23759C35F6314285C1D642E0F13B2BF3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>10E4A21EDDC41F94B30C17F38403E413</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252588F94F9C2291A3486B7067E69576</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>259498FBDA923366A8452198A57D1F08</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>9957AD0715343BA2E7013691E1E98F7F</string>
-			<key>buildPhases</key>
-			<array>
-				<string>F2F5FF28F679ADC8A92B329DFCDCE51F</string>
-				<string>1FFCDC3F1D5C704D66044A14414886F5</string>
-				<string>74D6B9A88E9B97B956BF27CEE1DADAC3</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>48D042132AC259FD381EA4D96E17C5B5</string>
-				<string>396DE1C1608FD26AC267D36844C6630E</string>
-				<string>743E721F930E22D28C87A28227016A4E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>productName</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>productReference</key>
-			<string>293CBC63DDF03144B25885047CA44A32</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>2692C5A026D6876DF0B8ED238232F2E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>28E4BFBF9D2ACEADF06BE12B21BDFFBB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>293CBC63DDF03144B25885047CA44A32</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_FayeSwift_Tests.framework</string>
-			<key>path</key>
-			<string>Pods_FayeSwift_Tests.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2A14E4E75C0921B8190FF7805BDB1994</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>SwiftyJSON.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2A8281B38766D2C9957F19E11DA20796</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>FayeSwift.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2B196DA7A8C6F18B3AB9B0D2CA7C570E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Starscream/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Starscream/Starscream.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>Starscream</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>2D4EF06156597B9C0C9800347C3343FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
-				<string>FB45FFD90572718D82AB9092B750F0CA</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2FDDE3F7149F856AAB928833D5658DB3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>WebsocketTransport.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2FE9E957D59ADA0A662E4B8C1A7BD7E2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>334521CDCF3F9A42442BD9C944494648</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-			<key>targetProxy</key>
-			<string>002C971AF7CA74392977401F3B5915E3</string>
-		</dict>
-		<key>344AD1F5AB3B588C01B21778050F2EAF</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-			<key>targetProxy</key>
-			<string>85FD64D2BAA74EAEF9935526FAFB1516</string>
-		</dict>
-		<key>37D9B4C012C932EED434E89C515FA960</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>38A444149F18F886FD0A1E23B45D6671</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SSLSecurity.swift</string>
-			<key>path</key>
-			<string>Source/SSLSecurity.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3928AADA2DE31A1110577AFF292046A8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>FayeSwift-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>396DE1C1608FD26AC267D36844C6630E</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-			<key>targetProxy</key>
-			<string>252588F94F9C2291A3486B7067E69576</string>
-		</dict>
-		<key>3BD0A2C746E213094BBD1A609EE7575F</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>72A65D8E20A55005994AAC51F0764161</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>3E94F4BAAE418F28A0730CC56D7FACFF</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Starscream.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4471A15D81938B6C2CE6A161EC41FEED</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>47C7E36F0C36BF6A9B7F26250E6F35CA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Starscream-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>47C81FB96686C0BE581D0FC3090AFC0D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Starscream.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4885D84AE492246F7B92A35D5F4C2787</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>48BC61B70DBB2FA057A57FF358488F76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0813DA1F91E6465D940389B245DB41E4</string>
-				<string>9BE8F84C840D474BB60E62D4A8259C63</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>path</key>
-			<string>SwiftyJSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>48D042132AC259FD381EA4D96E17C5B5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>target</key>
-			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
-			<key>targetProxy</key>
-			<string>B1C1530B6651528BC37303CE7401BF99</string>
-		</dict>
-		<key>4AB2D41C9043F185BD735AC2476F72C6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4D7A0A0B35C6A6AD7E9E0865060EEF5F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4F6AB79FA2ADEC11423A3782E26DC919</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3928AADA2DE31A1110577AFF292046A8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>5205B3C8BA6B671C4778F40FFC7FA2AC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F802A9E96DB8EBC2F1E349E2B2CD7D0A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>539B253953115DAEA00D55C65474A1F6</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E09B4B87B5F08505B3484854BDF5F693</string>
-				<string>A031FE4B914D5D75EED52D5B6438B92F</string>
-				<string>B61129D4F667E387188D25F633E0B629</string>
-				<string>F802A9E96DB8EBC2F1E349E2B2CD7D0A</string>
-				<string>BA68C21BEA9C15F85E840F5BCD06B262</string>
-				<string>2FDDE3F7149F856AAB928833D5658DB3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>path</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>55B757366E7A17818E9E92058B503641</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>57072CFE2F97B4E7645A18D9267BA425</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CFB3E404A66EE13E14582416D200A72C</string>
-				<string>ED0A84AABA966E6DE908E1D84ABB429E</string>
-				<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-				<string>18C6718FA411202146721CBD6539BA6A</string>
-				<string>47C7E36F0C36BF6A9B7F26250E6F35CA</string>
-				<string>D47E6B74B427A4904D75990D1C34E829</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Starscream</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5744E51CF8ECA084D92426D57DC945EF</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4F6AB79FA2ADEC11423A3782E26DC919</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>5B06E0872ABFC40563F3AA7BC14A699F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>38A444149F18F886FD0A1E23B45D6671</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>5B81CC02BA5C8A6F2E0D126266A157A1</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>D529A91B72E7AAA62AEB5E5A0E3A7114</string>
-				<string>BCCAAFB3C077A4CC7BD755B218914AF6</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>5CA1401B9C2AC9B84FD288DB6C3FC702</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>84EF024683CD3AA877927D77BAABE64F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>5D1E5C8AB017A941ACA43B001D23BCFA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>72A65D8E20A55005994AAC51F0764161</string>
-			<key>targetProxy</key>
-			<string>E641FD10F82298D81E564BF16487B827</string>
-		</dict>
-		<key>5E2995BA89319C883FC5F6B5525881A2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F8555866B482E99822581ABC579F3CD5</string>
-				<string>7B376196BBC05D9BB79CB4D466E47F1A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>64F09C054760D010B8E1B3BEB4671267</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_FayeSwift_Example.framework</string>
-			<key>path</key>
-			<string>Pods_FayeSwift_Example.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>66A658DA4AA077462390CB0E887E48E5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6A4FCAF5C9B5FE17B150653EFC153B3C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>2B196DA7A8C6F18B3AB9B0D2CA7C570E</string>
-				<string>AAE3D93BCF9437209130DA54E4664DD3</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>6B923F40E09322629BC57536AFBDAB00</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SwiftyJSON-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6C0CE301D9536F43B5C8E08E16712E38</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>2692C5A026D6876DF0B8ED238232F2E6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Example</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6CF3F2DD66CD874F21BF38ED13DD0295</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
-			<key>remoteInfo</key>
-			<string>FayeSwift</string>
-		</dict>
-		<key>6DCD25231745CBB7A0DE8AE144F32C35</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SwiftyJSON-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6E1FB52B709CB783F4109CA61174C28B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6F6B01E4869FC29404539D1F7EA47967</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5B06E0872ABFC40563F3AA7BC14A699F</string>
-				<string>C5681A6362FFDCE2DECBDEE5BFBC907C</string>
-				<string>E5F282A8CE41FC1844203FB427A39226</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6FE6036891606B3E61FED4812F318F99</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>539B253953115DAEA00D55C65474A1F6</string>
-				<string>DC2BFC3D7A2C4C8331A638C7C1007D20</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>70D1C0428C900D6671409303C06593E3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BA68C21BEA9C15F85E840F5BCD06B262</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>71A71AB65AF6D4590B241277504532F1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A031FE4B914D5D75EED52D5B6438B92F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>72A65D8E20A55005994AAC51F0764161</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>EE4323D789F482019F76D08873013AC9</string>
-			<key>buildPhases</key>
-			<array>
-				<string>5E2995BA89319C883FC5F6B5525881A2</string>
-				<string>1DDD99058CD940FD5917CA5AD774B011</string>
-				<string>DA4D3B670D373E4D9F2C0E061EF8C589</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>productName</key>
-			<string>SwiftyJSON</string>
-			<key>productReference</key>
-			<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>743E721F930E22D28C87A28227016A4E</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>72A65D8E20A55005994AAC51F0764161</string>
-			<key>targetProxy</key>
-			<string>A1B59F9DF18152F704FE8F577A69E455</string>
-		</dict>
-		<key>74D6B9A88E9B97B956BF27CEE1DADAC3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>23759C35F6314285C1D642E0F13B2BF3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>77F9AA324F09A90FB80ECB48C4E4BA1A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7B376196BBC05D9BB79CB4D466E47F1A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0813DA1F91E6465D940389B245DB41E4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>7DB346D0F39D3F0E887471402A8071AB</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
-				<string>1F6C69005CE5773E87D416DED050CEA8</string>
-				<string>0DB5BD81DCAEB161F8916282ABFD3340</string>
-				<string>0C03422930E80D7BB92C5C859589F09F</string>
-				<string>9A590701475CDEC7488348815ADACCBC</string>
-				<string>000A61D7F0D0221F20F470656F297E70</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8201936B74D25F4E7B4C6525D2B93E83</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>FayeSwift.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>84EF024683CD3AA877927D77BAABE64F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>85FD64D2BAA74EAEF9935526FAFB1516</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>87D64F48FA18233694918281C87E0266</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>WebSocket.swift</string>
-			<key>path</key>
-			<string>Source/WebSocket.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9228804A5CB29EF1E2D8F805F0EEA281</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Starscream.framework</string>
-			<key>path</key>
-			<string>Starscream.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>9361BD7539E0A621237603846E00D81E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F1C91701EDE25A8DF650080551A1EE5F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>968A19F12E6EEAFE1AF4E01F94F08D05</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>97A4D1CD8C418326C4A40D8446A9BAC8</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>72A65D8E20A55005994AAC51F0764161</string>
-			<key>targetProxy</key>
-			<string>3BD0A2C746E213094BBD1A609EE7575F</string>
-		</dict>
-		<key>9957AD0715343BA2E7013691E1E98F7F</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>9D3BE8B79BE19FBE664EBECF0B50D300</string>
-				<string>BA99F75B86D32E8C1D12F5167359D6E2</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>9A1314F41D4AF302873CCAE4DF95096E</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>SwiftyJSON.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>9A590701475CDEC7488348815ADACCBC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
-				<string>64F09C054760D010B8E1B3BEB4671267</string>
-				<string>293CBC63DDF03144B25885047CA44A32</string>
-				<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
-				<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9BE8F84C840D474BB60E62D4A8259C63</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E6671F9532A947F40918CF9A0D44F70F</string>
-				<string>2A14E4E75C0921B8190FF7805BDB1994</string>
-				<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-				<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
-				<string>0F0AD0445D068E37E1C8498A3BF6150D</string>
-				<string>6B923F40E09322629BC57536AFBDAB00</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/SwiftyJSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D3BE8B79BE19FBE664EBECF0B50D300</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Tests</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>A031FE4B914D5D75EED52D5B6438B92F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeClientDelegate.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A07DDD4070D07F0518CC9913F4C9E2D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B61129D4F667E387188D25F633E0B629</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>A1B59F9DF18152F704FE8F577A69E455</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>72A65D8E20A55005994AAC51F0764161</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>A64AB5E2E8029DC851944646B9BCCBB2</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>5B81CC02BA5C8A6F2E0D126266A157A1</string>
-			<key>buildPhases</key>
-			<array>
-				<string>EB11F02CBEFF194F4C17D9EFC26470D6</string>
-				<string>C5F66B163042240ECC70017F4B2423C7</string>
-				<string>5744E51CF8ECA084D92426D57DC945EF</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>334521CDCF3F9A42442BD9C944494648</string>
-				<string>97A4D1CD8C418326C4A40D8446A9BAC8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>productName</key>
-			<string>FayeSwift</string>
-			<key>productReference</key>
-			<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>A9DB76C98B77BAC9C5FB4172E70966EB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AAE3D93BCF9437209130DA54E4664DD3</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Starscream/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Starscream/Starscream.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>Starscream</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>AEC58E9B2FE610C5D55CBB2FA4D34F2A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6E1FB52B709CB783F4109CA61174C28B</string>
-				<string>37D9B4C012C932EED434E89C515FA960</string>
-				<string>4471A15D81938B6C2CE6A161EC41FEED</string>
-				<string>B29C7FFE8D08A56E77C644C03000FC94</string>
-				<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
-				<string>14B7C4FE824293ABEEF592A7E71C4AFC</string>
-				<string>4885D84AE492246F7B92A35D5F4C2787</string>
-				<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
-				<string>B661AAF1FC01F5B9EB53567F4990C215</string>
-				<string>2692C5A026D6876DF0B8ED238232F2E6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-FayeSwift_Example</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B0F7AB6108413A1758B2F2D999AED350</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>17665D60312637FC3C2207AEFD337BAD</string>
-			<key>buildPhases</key>
-			<array>
-				<string>5CA1401B9C2AC9B84FD288DB6C3FC702</string>
-				<string>E307332C7150A001B3765B245D2D6839</string>
-				<string>22E6B7DDC8DADDE451326034FD9E9C8E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>050F3648989E5C1D6979F7A0EDAA352A</string>
-				<string>344AD1F5AB3B588C01B21778050F2EAF</string>
-				<string>5D1E5C8AB017A941ACA43B001D23BCFA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>productName</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>productReference</key>
-			<string>64F09C054760D010B8E1B3BEB4671267</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>B1C1530B6651528BC37303CE7401BF99</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
-			<key>remoteInfo</key>
-			<string>FayeSwift</string>
-		</dict>
-		<key>B267AB921ABBC8B1A9D9D568D0D05615</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>SwiftyJSON.framework</string>
-			<key>path</key>
-			<string>SwiftyJSON.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B29C7FFE8D08A56E77C644C03000FC94</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B60722EF6A0F9DCD2D7C6D03F8B362CD</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>38A444149F18F886FD0A1E23B45D6671</string>
-				<string>87D64F48FA18233694918281C87E0266</string>
-				<string>57072CFE2F97B4E7645A18D9267BA425</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>path</key>
-			<string>Starscream</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B61129D4F667E387188D25F633E0B629</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>NSError+Helper.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B661AAF1FC01F5B9EB53567F4990C215</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B67F6FB5E88D459FDF1CC4FD93CB5D6B</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>FayeSwift.framework</string>
-			<key>path</key>
-			<string>FayeSwift.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B8D637FB9D47D77BBA1D7A37CE57E05F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>B9BD316B84610E564DEC11C4F736BD36</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>BA68C21BEA9C15F85E840F5BCD06B262</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>Transport.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BA99F75B86D32E8C1D12F5167359D6E2</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>4AB2D41C9043F185BD735AC2476F72C6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Tests</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>BB8D9E76FCCFA23D18222577B77988FB</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/SwiftyJSON/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>SwiftyJSON</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>BCCAAFB3C077A4CC7BD755B218914AF6</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8201936B74D25F4E7B4C6525D2B93E83</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/FayeSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>FayeSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>C05B711322CA076AB9A57512649A029E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>B661AAF1FC01F5B9EB53567F4990C215</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Example</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>C3E208C52EE6C8C0689C1B94807309CD</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>28E4BFBF9D2ACEADF06BE12B21BDFFBB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>C5681A6362FFDCE2DECBDEE5BFBC907C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C6718FA411202146721CBD6539BA6A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C5F66B163042240ECC70017F4B2423C7</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>112044DE1A7A5E8036447F0CC4CA58CB</string>
-				<string>A9DB76C98B77BAC9C5FB4172E70966EB</string>
-				<string>0D76A5AF0D4781BFAC4D92B66E3A30B4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>CB53D08DB5954932A4741A1969F2C195</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/SwiftyJSON/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>SwiftyJSON</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>CFB3E404A66EE13E14582416D200A72C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D26B5E2282A330BE919FE4EFDFB738B3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D33279C9153C75C4AD5A47272F4E6BA8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>FayeSwift-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D41D8CD98F00B204E9800998ECF8427E</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastSwiftUpdateCheck</key>
-				<string>0700</string>
-				<key>LastUpgradeCheck</key>
-				<string>0700</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>7DB346D0F39D3F0E887471402A8071AB</string>
-			<key>productRefGroup</key>
-			<string>9A590701475CDEC7488348815ADACCBC</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
-				<string>B0F7AB6108413A1758B2F2D999AED350</string>
-				<string>259498FBDA923366A8452198A57D1F08</string>
-				<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
-				<string>72A65D8E20A55005994AAC51F0764161</string>
-			</array>
-		</dict>
-		<key>D47E6B74B427A4904D75990D1C34E829</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Starscream-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D529A91B72E7AAA62AEB5E5A0E3A7114</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8201936B74D25F4E7B4C6525D2B93E83</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/FayeSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>FayeSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>D7AD1CA221F811429F2397EA408725EE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1DCE2224000629085D044E4A5FDB2710</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DA4D3B670D373E4D9F2C0E061EF8C589</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>1D9F765D7226F81517EEACB2B6EE02D6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>DC2BFC3D7A2C4C8331A638C7C1007D20</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2A8281B38766D2C9957F19E11DA20796</string>
-				<string>8201936B74D25F4E7B4C6525D2B93E83</string>
-				<string>D33279C9153C75C4AD5A47272F4E6BA8</string>
-				<string>FA96A146A7D76D7C1EEA5F97736E1F0D</string>
-				<string>3928AADA2DE31A1110577AFF292046A8</string>
-				<string>77F9AA324F09A90FB80ECB48C4E4BA1A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Example/Pods/Target Support Files/FayeSwift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E09B4B87B5F08505B3484854BDF5F693</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeClient.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E307332C7150A001B3765B245D2D6839</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>968A19F12E6EEAFE1AF4E01F94F08D05</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E4E07C18061452192A8755C57422BE93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E5F282A8CE41FC1844203FB427A39226</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87D64F48FA18233694918281C87E0266</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>E641FD10F82298D81E564BF16487B827</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>72A65D8E20A55005994AAC51F0764161</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>E6671F9532A947F40918CF9A0D44F70F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EB11F02CBEFF194F4C17D9EFC26470D6</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>172D87FC5B15E2E05E643DD1188F953D</string>
-				<string>71A71AB65AF6D4590B241277504532F1</string>
-				<string>FF0CA1F99F12CC1A9B852F6601921D99</string>
-				<string>A07DDD4070D07F0518CC9913F4C9E2D6</string>
-				<string>5205B3C8BA6B671C4778F40FFC7FA2AC</string>
-				<string>70D1C0428C900D6671409303C06593E3</string>
-				<string>F465C9735101FE983DA25543F4066F9A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>ED0A84AABA966E6DE908E1D84ABB429E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Starscream.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EE4323D789F482019F76D08873013AC9</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>BB8D9E76FCCFA23D18222577B77988FB</string>
-				<string>CB53D08DB5954932A4741A1969F2C195</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F1C91701EDE25A8DF650080551A1EE5F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D47E6B74B427A4904D75990D1C34E829</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>F2F5FF28F679ADC8A92B329DFCDCE51F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>D7AD1CA221F811429F2397EA408725EE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F3FCAA0DF279AAE5F2E8878F0749DD44</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F465C9735101FE983DA25543F4066F9A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2FDDE3F7149F856AAB928833D5658DB3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>F802A9E96DB8EBC2F1E349E2B2CD7D0A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>StringExtensions.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F8555866B482E99822581ABC579F3CD5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FA96A146A7D76D7C1EEA5F97736E1F0D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>FayeSwift-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FB45FFD90572718D82AB9092B750F0CA</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>FF0CA1F99F12CC1A9B852F6601921D99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D33279C9153C75C4AD5A47272F4E6BA8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>D41D8CD98F00B204E9800998ECF8427E</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		0D76A5AF0D4781BFAC4D92B66E3A30B4 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */; };
+		112044DE1A7A5E8036447F0CC4CA58CB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		172D87FC5B15E2E05E643DD1188F953D /* FayeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1D9F765D7226F81517EEACB2B6EE02D6 /* SwiftyJSON-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		28E4BFBF9D2ACEADF06BE12B21BDFFBB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		4F6AB79FA2ADEC11423A3782E26DC919 /* FayeSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3928AADA2DE31A1110577AFF292046A8 /* FayeSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5205B3C8BA6B671C4778F40FFC7FA2AC /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B06E0872ABFC40563F3AA7BC14A699F /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		66A658DA4AA077462390CB0E887E48E5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		70D1C0428C900D6671409303C06593E3 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA68C21BEA9C15F85E840F5BCD06B262 /* Transport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		71A71AB65AF6D4590B241277504532F1 /* FayeClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7B376196BBC05D9BB79CB4D466E47F1A /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */; };
+		968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		A07DDD4070D07F0518CC9913F4C9E2D6 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A9DB76C98B77BAC9C5FB4172E70966EB /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
+		C5681A6362FFDCE2DECBDEE5BFBC907C /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
+		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
+		E5F282A8CE41FC1844203FB427A39226 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F1C91701EDE25A8DF650080551A1EE5F /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F465C9735101FE983DA25543F4066F9A /* WebsocketTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDDE3F7149F856AAB928833D5658DB3 /* WebsocketTransport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F8555866B482E99822581ABC579F3CD5 /* SwiftyJSON-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */; };
+		FF0CA1F99F12CC1A9B852F6601921D99 /* FayeSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		002C971AF7CA74392977401F3B5915E3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0FFB2621535432DEA9289D0F9EEEE26C;
+			remoteInfo = Starscream;
+		};
+		252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0FFB2621535432DEA9289D0F9EEEE26C;
+			remoteInfo = Starscream;
+		};
+		3BD0A2C746E213094BBD1A609EE7575F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 72A65D8E20A55005994AAC51F0764161;
+			remoteInfo = SwiftyJSON;
+		};
+		6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A64AB5E2E8029DC851944646B9BCCBB2;
+			remoteInfo = FayeSwift;
+		};
+		85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0FFB2621535432DEA9289D0F9EEEE26C;
+			remoteInfo = Starscream;
+		};
+		A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 72A65D8E20A55005994AAC51F0764161;
+			remoteInfo = SwiftyJSON;
+		};
+		B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A64AB5E2E8029DC851944646B9BCCBB2;
+			remoteInfo = FayeSwift;
+		};
+		E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 72A65D8E20A55005994AAC51F0764161;
+			remoteInfo = SwiftyJSON;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Example-umbrella.h"; sourceTree = "<group>"; };
+		0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
+		0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
+		10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Tests-umbrella.h"; sourceTree = "<group>"; };
+		14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-frameworks.sh"; sourceTree = "<group>"; };
+		154C747E02B1DCBD4885645B5878477F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Starscream-dummy.m"; sourceTree = "<group>"; };
+		1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Tests-dummy.m"; sourceTree = "<group>"; };
+		1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
+		2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
+		293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
+		2A8281B38766D2C9957F19E11DA20796 /* FayeSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = FayeSwift.modulemap; sourceTree = "<group>"; };
+		2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		2FDDE3F7149F856AAB928833D5658DB3 /* WebsocketTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebsocketTransport.swift; sourceTree = "<group>"; };
+		2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Example-dummy.m"; sourceTree = "<group>"; };
+		37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Example.modulemap"; sourceTree = "<group>"; };
+		38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Source/SSLSecurity.swift; sourceTree = "<group>"; };
+		3928AADA2DE31A1110577AFF292046A8 /* FayeSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-umbrella.h"; sourceTree = "<group>"; };
+		3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-prefix.pch"; sourceTree = "<group>"; };
+		47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.xcconfig; sourceTree = "<group>"; };
+		4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-resources.sh"; sourceTree = "<group>"; };
+		4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
+		6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftyJSON-dummy.m"; sourceTree = "<group>"; };
+		6E1FB52B709CB783F4109CA61174C28B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77F9AA324F09A90FB80ECB48C4E4BA1A /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FayeSwift.xcconfig; sourceTree = "<group>"; };
+		87D64F48FA18233694918281C87E0266 /* WebSocket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Source/WebSocket.swift; sourceTree = "<group>"; };
+		9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClientDelegate.swift; sourceTree = "<group>"; };
+		B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Helper.swift"; sourceTree = "<group>"; };
+		B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FayeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-resources.sh"; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BA68C21BEA9C15F85E840F5BCD06B262 /* Transport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		CFB3E404A66EE13E14582416D200A72C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
+		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
+		E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
+		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Starscream.modulemap; sourceTree = "<group>"; };
+		F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Tests.modulemap"; sourceTree = "<group>"; };
+		F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		FA96A146A7D76D7C1EEA5F97736E1F0D /* FayeSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-prefix.pch"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1DDD99058CD940FD5917CA5AD774B011 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66A658DA4AA077462390CB0E887E48E5 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C3E208C52EE6C8C0689C1B94807309CD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				28E4BFBF9D2ACEADF06BE12B21BDFFBB /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C5F66B163042240ECC70017F4B2423C7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				112044DE1A7A5E8036447F0CC4CA58CB /* Foundation.framework in Frameworks */,
+				A9DB76C98B77BAC9C5FB4172E70966EB /* Starscream.framework in Frameworks */,
+				0D76A5AF0D4781BFAC4D92B66E3A30B4 /* SwiftyJSON.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E307332C7150A001B3765B245D2D6839 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */,
+				0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				154C747E02B1DCBD4885645B5878477F /* Info.plist */,
+				F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */,
+				2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */,
+				15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */,
+				1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */,
+				E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */,
+				B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */,
+				10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */,
+				D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */,
+				4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */,
+			);
+			name = "Pods-FayeSwift_Tests";
+			path = "Target Support Files/Pods-FayeSwift_Tests";
+			sourceTree = "<group>";
+		};
+		0C03422930E80D7BB92C5C859589F09F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */,
+				48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */,
+				9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */,
+				4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6FE6036891606B3E61FED4812F318F99 /* FayeSwift */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */ = {
+			isa = PBXGroup;
+			children = (
+				0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */,
+				9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */,
+			);
+			path = SwiftyJSON;
+			sourceTree = "<group>";
+		};
+		4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		539B253953115DAEA00D55C65474A1F6 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				E09B4B87B5F08505B3484854BDF5F693 /* FayeClient.swift */,
+				A031FE4B914D5D75EED52D5B6438B92F /* FayeClientDelegate.swift */,
+				B61129D4F667E387188D25F633E0B629 /* NSError+Helper.swift */,
+				F802A9E96DB8EBC2F1E349E2B2CD7D0A /* StringExtensions.swift */,
+				BA68C21BEA9C15F85E840F5BCD06B262 /* Transport.swift */,
+				2FDDE3F7149F856AAB928833D5658DB3 /* WebsocketTransport.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		57072CFE2F97B4E7645A18D9267BA425 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				CFB3E404A66EE13E14582416D200A72C /* Info.plist */,
+				ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */,
+				47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */,
+				18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */,
+				47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */,
+				D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Starscream";
+			sourceTree = "<group>";
+		};
+		6FE6036891606B3E61FED4812F318F99 /* FayeSwift */ = {
+			isa = PBXGroup;
+			children = (
+				539B253953115DAEA00D55C65474A1F6 /* Sources */,
+				DC2BFC3D7A2C4C8331A638C7C1007D20 /* Support Files */,
+			);
+			name = FayeSwift;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */,
+				0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */,
+				0C03422930E80D7BB92C5C859589F09F /* Pods */,
+				9A590701475CDEC7488348815ADACCBC /* Products */,
+				000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		9A590701475CDEC7488348815ADACCBC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */,
+				64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */,
+				293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */,
+				9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */,
+				B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E6671F9532A947F40918CF9A0D44F70F /* Info.plist */,
+				2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */,
+				1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */,
+				6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */,
+				0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */,
+				6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/SwiftyJSON";
+			sourceTree = "<group>";
+		};
+		AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */ = {
+			isa = PBXGroup;
+			children = (
+				6E1FB52B709CB783F4109CA61174C28B /* Info.plist */,
+				37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */,
+				4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */,
+				B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */,
+				2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */,
+				14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */,
+				4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */,
+				06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */,
+				B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */,
+				2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */,
+			);
+			name = "Pods-FayeSwift_Example";
+			path = "Target Support Files/Pods-FayeSwift_Example";
+			sourceTree = "<group>";
+		};
+		B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */ = {
+			isa = PBXGroup;
+			children = (
+				38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */,
+				87D64F48FA18233694918281C87E0266 /* WebSocket.swift */,
+				57072CFE2F97B4E7645A18D9267BA425 /* Support Files */,
+			);
+			path = Starscream;
+			sourceTree = "<group>";
+		};
+		DC2BFC3D7A2C4C8331A638C7C1007D20 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				2A8281B38766D2C9957F19E11DA20796 /* FayeSwift.modulemap */,
+				8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */,
+				D33279C9153C75C4AD5A47272F4E6BA8 /* FayeSwift-dummy.m */,
+				FA96A146A7D76D7C1EEA5F97736E1F0D /* FayeSwift-prefix.pch */,
+				3928AADA2DE31A1110577AFF292046A8 /* FayeSwift-umbrella.h */,
+				77F9AA324F09A90FB80ECB48C4E4BA1A /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/FayeSwift";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5744E51CF8ECA084D92426D57DC945EF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4F6AB79FA2ADEC11423A3782E26DC919 /* FayeSwift-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9361BD7539E0A621237603846E00D81E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1C91701EDE25A8DF650080551A1EE5F /* Starscream-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA4D3B670D373E4D9F2C0E061EF8C589 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D9F765D7226F81517EEACB2B6EE02D6 /* SwiftyJSON-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6A4FCAF5C9B5FE17B150653EFC153B3C /* Build configuration list for PBXNativeTarget "Starscream" */;
+			buildPhases = (
+				6F6B01E4869FC29404539D1F7EA47967 /* Sources */,
+				C3E208C52EE6C8C0689C1B94807309CD /* Frameworks */,
+				9361BD7539E0A621237603846E00D81E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Starscream;
+			productName = Starscream;
+			productReference = 9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */;
+			buildPhases = (
+				F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */,
+				1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */,
+				74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */,
+				396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */,
+				743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */,
+			);
+			name = "Pods-FayeSwift_Tests";
+			productName = "Pods-FayeSwift_Tests";
+			productReference = 293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EE4323D789F482019F76D08873013AC9 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
+			buildPhases = (
+				5E2995BA89319C883FC5F6B5525881A2 /* Sources */,
+				1DDD99058CD940FD5917CA5AD774B011 /* Frameworks */,
+				DA4D3B670D373E4D9F2C0E061EF8C589 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftyJSON;
+			productName = SwiftyJSON;
+			productReference = B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B81CC02BA5C8A6F2E0D126266A157A1 /* Build configuration list for PBXNativeTarget "FayeSwift" */;
+			buildPhases = (
+				EB11F02CBEFF194F4C17D9EFC26470D6 /* Sources */,
+				C5F66B163042240ECC70017F4B2423C7 /* Frameworks */,
+				5744E51CF8ECA084D92426D57DC945EF /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				334521CDCF3F9A42442BD9C944494648 /* PBXTargetDependency */,
+				97A4D1CD8C418326C4A40D8446A9BAC8 /* PBXTargetDependency */,
+			);
+			name = FayeSwift;
+			productName = FayeSwift;
+			productReference = B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */;
+			buildPhases = (
+				5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */,
+				E307332C7150A001B3765B245D2D6839 /* Frameworks */,
+				22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */,
+				344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */,
+				5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */,
+			);
+			name = "Pods-FayeSwift_Example";
+			productName = "Pods-FayeSwift_Example";
+			productReference = 64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0730;
+			};
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 9A590701475CDEC7488348815ADACCBC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */,
+				B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */,
+				259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */,
+				0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */,
+				72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5E2995BA89319C883FC5F6B5525881A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8555866B482E99822581ABC579F3CD5 /* SwiftyJSON-dummy.m in Sources */,
+				7B376196BBC05D9BB79CB4D466E47F1A /* SwiftyJSON.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F6B01E4869FC29404539D1F7EA47967 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B06E0872ABFC40563F3AA7BC14A699F /* SSLSecurity.swift in Sources */,
+				C5681A6362FFDCE2DECBDEE5BFBC907C /* Starscream-dummy.m in Sources */,
+				E5F282A8CE41FC1844203FB427A39226 /* WebSocket.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB11F02CBEFF194F4C17D9EFC26470D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				172D87FC5B15E2E05E643DD1188F953D /* FayeClient.swift in Sources */,
+				71A71AB65AF6D4590B241277504532F1 /* FayeClientDelegate.swift in Sources */,
+				FF0CA1F99F12CC1A9B852F6601921D99 /* FayeSwift-dummy.m in Sources */,
+				A07DDD4070D07F0518CC9913F4C9E2D6 /* NSError+Helper.swift in Sources */,
+				5205B3C8BA6B671C4778F40FFC7FA2AC /* StringExtensions.swift in Sources */,
+				70D1C0428C900D6671409303C06593E3 /* Transport.swift in Sources */,
+				F465C9735101FE983DA25543F4066F9A /* WebsocketTransport.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FayeSwift;
+			target = A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */;
+			targetProxy = 6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */;
+		};
+		334521CDCF3F9A42442BD9C944494648 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */;
+			targetProxy = 002C971AF7CA74392977401F3B5915E3 /* PBXContainerItemProxy */;
+		};
+		344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */;
+			targetProxy = 85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */;
+		};
+		396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 0FFB2621535432DEA9289D0F9EEEE26C /* Starscream */;
+			targetProxy = 252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */;
+		};
+		48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FayeSwift;
+			target = A64AB5E2E8029DC851944646B9BCCBB2 /* FayeSwift */;
+			targetProxy = B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */;
+		};
+		5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = 72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */;
+			targetProxy = E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */;
+		};
+		743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = 72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */;
+			targetProxy = A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */;
+		};
+		97A4D1CD8C418326C4A40D8446A9BAC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = 72A65D8E20A55005994AAC51F0764161 /* SwiftyJSON */;
+			targetProxy = 3BD0A2C746E213094BBD1A609EE7575F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		2B196DA7A8C6F18B3AB9B0D2CA7C570E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Starscream;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6C0CE301D9536F43B5C8E08E16712E38 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Pods_FayeSwift_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Pods_FayeSwift_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		AAE3D93BCF9437209130DA54E4664DD3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Starscream;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BA99F75B86D32E8C1D12F5167359D6E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Pods_FayeSwift_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BB8D9E76FCCFA23D18222577B77988FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BCCAAFB3C077A4CC7BD755B218914AF6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = FayeSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C05B711322CA076AB9A57512649A029E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Pods_FayeSwift_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		CB53D08DB5954932A4741A1969F2C195 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D529A91B72E7AAA62AEB5E5A0E3A7114 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8201936B74D25F4E7B4C6525D2B93E83 /* FayeSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = FayeSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C05B711322CA076AB9A57512649A029E /* Debug */,
+				6C0CE301D9536F43B5C8E08E16712E38 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
+				FB45FFD90572718D82AB9092B750F0CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B81CC02BA5C8A6F2E0D126266A157A1 /* Build configuration list for PBXNativeTarget "FayeSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D529A91B72E7AAA62AEB5E5A0E3A7114 /* Debug */,
+				BCCAAFB3C077A4CC7BD755B218914AF6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6A4FCAF5C9B5FE17B150653EFC153B3C /* Build configuration list for PBXNativeTarget "Starscream" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2B196DA7A8C6F18B3AB9B0D2CA7C570E /* Debug */,
+				AAE3D93BCF9437209130DA54E4664DD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */,
+				BA99F75B86D32E8C1D12F5167359D6E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EE4323D789F482019F76D08873013AC9 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BB8D9E76FCCFA23D18222577B77988FB /* Debug */,
+				CB53D08DB5954932A4741A1969F2C195 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+}

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,2718 +1,1151 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>000A61D7F0D0221F20F470656F297E70</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AEC58E9B2FE610C5D55CBB2FA4D34F2A</string>
-				<string>0A3C1A1DE210D08A1510BD9669BDF551</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>050F3648989E5C1D6979F7A0EDAA352A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>target</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>targetProxy</key>
-			<string>6CF3F2DD66CD874F21BF38ED13DD0295</string>
-		</dict>
-		<key>06B16C30B7CF62C246F4DD2B6BA325D2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0813DA1F91E6465D940389B245DB41E4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SwiftyJSON.swift</string>
-			<key>path</key>
-			<string>Source/SwiftyJSON.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>08C9E34BFE3CE6E33FB4863BF08E5C1B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5EA65666CE5344D192D5B67A85CAFA39</string>
-				<string>D5A61BB662B60E80642A24E32724275E</string>
-				<string>548BDBC634056C39A523C64AB1870D93</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0A3C1A1DE210D08A1510BD9669BDF551</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>154C747E02B1DCBD4885645B5878477F</string>
-				<string>F3FCAA0DF279AAE5F2E8878F0749DD44</string>
-				<string>2D4EF06156597B9C0C9800347C3343FC</string>
-				<string>15765D47A6F3AC9E1A1D641D8B2ADB93</string>
-				<string>1DCE2224000629085D044E4A5FDB2710</string>
-				<string>E4E07C18061452192A8755C57422BE93</string>
-				<string>B9BD316B84610E564DEC11C4F736BD36</string>
-				<string>10E4A21EDDC41F94B30C17F38403E413</string>
-				<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
-				<string>4AB2D41C9043F185BD735AC2476F72C6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-FayeSwift_Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0A3C59C66401164839B33852471AF8AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0AC47F7781401C3893E4D44D51617586</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>18B303F193AF762CF2DBE56F6B24B5CE</string>
-				<string>957ADEE6257BB32E03F9E872F76D3479</string>
-				<string>704BC00CA3D5CF10EF09C356B799A500</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0AEC95D7E93685709B9C6A5B00BDDEB7</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3434E7FC44AEA830A2C6B752B26BCE33</string>
-				<string>0BF6F830DDC0BFF42803E165FB1B2621</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>0BF6F830DDC0BFF42803E165FB1B2621</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/SwiftyJSON/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>SwiftyJSON</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>0C03422930E80D7BB92C5C859589F09F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B60722EF6A0F9DCD2D7C6D03F8B362CD</string>
-				<string>48BC61B70DBB2FA057A57FF358488F76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0C93A0CF1060B47E24A8905CE9F33ED1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5A3750120EFC5FE7B1FF72E6AE18A998</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0DB5BD81DCAEB161F8916282ABFD3340</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
-				<string>9A1314F41D4AF302873CCAE4DF95096E</string>
-				<string>4D7A0A0B35C6A6AD7E9E0865060EEF5F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0E62CB0F51CFEF3EF98705FE6ED1BAA1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>B7098005E3463F71E30EE2ACC3981519</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0F0AD0445D068E37E1C8498A3BF6150D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SwiftyJSON-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>10E4A21EDDC41F94B30C17F38403E413</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>143405C094ED81774A475A1A942BA220</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E83328805FF2933A2C3CEF374AFC4887</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>14B7C4FE824293ABEEF592A7E71C4AFC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>154C747E02B1DCBD4885645B5878477F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>155E3FCDB75DFDBB152E101B4C202295</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>FayeSwift-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15765D47A6F3AC9E1A1D641D8B2ADB93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>17665D60312637FC3C2207AEFD337BAD</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>C05B711322CA076AB9A57512649A029E</string>
-				<string>6C0CE301D9536F43B5C8E08E16712E38</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>18B303F193AF762CF2DBE56F6B24B5CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>18C6718FA411202146721CBD6539BA6A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Starscream-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1DCE2224000629085D044E4A5FDB2710</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1EC0280E5CCCCD96F81E63B562E157DD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>SwiftyJSON.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1F6C69005CE5773E87D416DED050CEA8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9E350CCD50346BBEAD007279DA919999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1FACCE2E2A3269AA6618DC62E86A5B78</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8128B73B46CE4E130156947FEA792793</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/FayeSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>FayeSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>1FFCDC3F1D5C704D66044A14414886F5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0A3C59C66401164839B33852471AF8AF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>22E6B7DDC8DADDE451326034FD9E9C8E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>55B757366E7A17818E9E92058B503641</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>23759C35F6314285C1D642E0F13B2BF3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>10E4A21EDDC41F94B30C17F38403E413</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252588F94F9C2291A3486B7067E69576</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>259498FBDA923366A8452198A57D1F08</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>9957AD0715343BA2E7013691E1E98F7F</string>
-			<key>buildPhases</key>
-			<array>
-				<string>F2F5FF28F679ADC8A92B329DFCDCE51F</string>
-				<string>1FFCDC3F1D5C704D66044A14414886F5</string>
-				<string>74D6B9A88E9B97B956BF27CEE1DADAC3</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>48D042132AC259FD381EA4D96E17C5B5</string>
-				<string>396DE1C1608FD26AC267D36844C6630E</string>
-				<string>743E721F930E22D28C87A28227016A4E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>productName</key>
-			<string>Pods-FayeSwift_Tests</string>
-			<key>productReference</key>
-			<string>293CBC63DDF03144B25885047CA44A32</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>2692C5A026D6876DF0B8ED238232F2E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>284F69195E7B74EADDB82148FD5DC647</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>2901A0000603C63521D4DED64D2B4586</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
-				<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
-				<string>E83328805FF2933A2C3CEF374AFC4887</string>
-				<string>487A65235BC761C63EA749D3504478B5</string>
-				<string>61F102DBDE488931620E8AA49183513B</string>
-				<string>B98F1A78B8406D8DE50340A8632588E9</string>
-				<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Sources</string>
-			<key>path</key>
-			<string>Sources</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>293CBC63DDF03144B25885047CA44A32</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_FayeSwift_Tests.framework</string>
-			<key>path</key>
-			<string>Pods_FayeSwift_Tests.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2A14E4E75C0921B8190FF7805BDB1994</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>SwiftyJSON.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2D4EF06156597B9C0C9800347C3343FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
-				<string>FB45FFD90572718D82AB9092B750F0CA</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2D9BE4E9101DCFEEF862D023F09073FA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>FayeSwift.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2FE9E957D59ADA0A662E4B8C1A7BD7E2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2FFB5CE6155C8F4095C8976A29498960</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>3EEFF32D5BCC2D64205AA37299BC9746</string>
-			<key>buildPhases</key>
-			<array>
-				<string>08C9E34BFE3CE6E33FB4863BF08E5C1B</string>
-				<string>0E62CB0F51CFEF3EF98705FE6ED1BAA1</string>
-				<string>0C93A0CF1060B47E24A8905CE9F33ED1</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>productName</key>
-			<string>Starscream</string>
-			<key>productReference</key>
-			<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>3434E7FC44AEA830A2C6B752B26BCE33</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/SwiftyJSON/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>SwiftyJSON</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>344AD1F5AB3B588C01B21778050F2EAF</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>targetProxy</key>
-			<string>85FD64D2BAA74EAEF9935526FAFB1516</string>
-		</dict>
-		<key>37D9B4C012C932EED434E89C515FA960</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>38A444149F18F886FD0A1E23B45D6671</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SSLSecurity.swift</string>
-			<key>path</key>
-			<string>Source/SSLSecurity.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>396DE1C1608FD26AC267D36844C6630E</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>targetProxy</key>
-			<string>252588F94F9C2291A3486B7067E69576</string>
-		</dict>
-		<key>3E94F4BAAE418F28A0730CC56D7FACFF</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Starscream.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>3EEFF32D5BCC2D64205AA37299BC9746</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>B93968102E7FD3EAE8BED45C989328EF</string>
-				<string>82721887C459F67368E0CF06D91C7E57</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>40CE25E3C0BCCCA4C2AF868C127EE751</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>target</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>targetProxy</key>
-			<string>88B85D4B1942F047C1DC470C922B7703</string>
-		</dict>
-		<key>4471A15D81938B6C2CE6A161EC41FEED</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>47C7E36F0C36BF6A9B7F26250E6F35CA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Starscream-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>47C81FB96686C0BE581D0FC3090AFC0D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Starscream.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>487A65235BC761C63EA749D3504478B5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>NSError+Helper.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4885D84AE492246F7B92A35D5F4C2787</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>48BC61B70DBB2FA057A57FF358488F76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0813DA1F91E6465D940389B245DB41E4</string>
-				<string>9BE8F84C840D474BB60E62D4A8259C63</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>path</key>
-			<string>SwiftyJSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>48D042132AC259FD381EA4D96E17C5B5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>target</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>targetProxy</key>
-			<string>B1C1530B6651528BC37303CE7401BF99</string>
-		</dict>
-		<key>49EE77FDD417AD6D8551E84B667F057D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>4AB2D41C9043F185BD735AC2476F72C6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4D7A0A0B35C6A6AD7E9E0865060EEF5F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5171549988DEFF7760E6073814FFA524</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>548BDBC634056C39A523C64AB1870D93</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87D64F48FA18233694918281C87E0266</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>55B757366E7A17818E9E92058B503641</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>57072CFE2F97B4E7645A18D9267BA425</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CFB3E404A66EE13E14582416D200A72C</string>
-				<string>ED0A84AABA966E6DE908E1D84ABB429E</string>
-				<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-				<string>18C6718FA411202146721CBD6539BA6A</string>
-				<string>47C7E36F0C36BF6A9B7F26250E6F35CA</string>
-				<string>D47E6B74B427A4904D75990D1C34E829</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Starscream</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5A3750120EFC5FE7B1FF72E6AE18A998</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D47E6B74B427A4904D75990D1C34E829</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>5CA1401B9C2AC9B84FD288DB6C3FC702</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>84EF024683CD3AA877927D77BAABE64F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>5D1E5C8AB017A941ACA43B001D23BCFA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>targetProxy</key>
-			<string>E641FD10F82298D81E564BF16487B827</string>
-		</dict>
-		<key>5EA65666CE5344D192D5B67A85CAFA39</key>
-		<dict>
-			<key>fileRef</key>
-			<string>38A444149F18F886FD0A1E23B45D6671</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>61F102DBDE488931620E8AA49183513B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>StringExtensions.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>62E2EDCCDEE8B32C1115DA2D9C6361CC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>WebsocketTransport.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>64F09C054760D010B8E1B3BEB4671267</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_FayeSwift_Example.framework</string>
-			<key>path</key>
-			<string>Pods_FayeSwift_Example.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>6B923F40E09322629BC57536AFBDAB00</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SwiftyJSON-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6C0CE301D9536F43B5C8E08E16712E38</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>2692C5A026D6876DF0B8ED238232F2E6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Example</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6CF3F2DD66CD874F21BF38ED13DD0295</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>remoteInfo</key>
-			<string>FayeSwift</string>
-		</dict>
-		<key>6DCD25231745CBB7A0DE8AE144F32C35</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SwiftyJSON-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6E1FB52B709CB783F4109CA61174C28B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>704BC00CA3D5CF10EF09C356B799A500</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9A1314F41D4AF302873CCAE4DF95096E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>743E721F930E22D28C87A28227016A4E</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>targetProxy</key>
-			<string>A1B59F9DF18152F704FE8F577A69E455</string>
-		</dict>
-		<key>74D6B9A88E9B97B956BF27CEE1DADAC3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>23759C35F6314285C1D642E0F13B2BF3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>786D4D05CB5776378133906FD2A40DE6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B98F1A78B8406D8DE50340A8632588E9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>7B7998CBFC4F64B40662D5BE2471EA16</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6B923F40E09322629BC57536AFBDAB00</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>7DB346D0F39D3F0E887471402A8071AB</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
-				<string>1F6C69005CE5773E87D416DED050CEA8</string>
-				<string>0DB5BD81DCAEB161F8916282ABFD3340</string>
-				<string>0C03422930E80D7BB92C5C859589F09F</string>
-				<string>9A590701475CDEC7488348815ADACCBC</string>
-				<string>000A61D7F0D0221F20F470656F297E70</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7F7A42B67F6F0E9E305772EB90285630</key>
-		<dict>
-			<key>fileRef</key>
-			<string>487A65235BC761C63EA749D3504478B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>7FCD02EA8C46A7BE4F4C55DF12CEB124</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>1FACCE2E2A3269AA6618DC62E86A5B78</string>
-				<string>FB4DED77D2E4800415AEB7F77228E2A1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>8128B73B46CE4E130156947FEA792793</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>FayeSwift.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>82721887C459F67368E0CF06D91C7E57</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Starscream/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Starscream/Starscream.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>Starscream</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>84EF024683CD3AA877927D77BAABE64F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>85FD64D2BAA74EAEF9935526FAFB1516</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>86074C31635E6527FE9EB5D3D6DE479B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>87D64F48FA18233694918281C87E0266</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>WebSocket.swift</string>
-			<key>path</key>
-			<string>Source/WebSocket.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>88B85D4B1942F047C1DC470C922B7703</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2FFB5CE6155C8F4095C8976A29498960</string>
-			<key>remoteInfo</key>
-			<string>Starscream</string>
-		</dict>
-		<key>9228804A5CB29EF1E2D8F805F0EEA281</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Starscream.framework</string>
-			<key>path</key>
-			<string>Starscream.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>957ADEE6257BB32E03F9E872F76D3479</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>968A19F12E6EEAFE1AF4E01F94F08D05</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957AD0715343BA2E7013691E1E98F7F</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>9D3BE8B79BE19FBE664EBECF0B50D300</string>
-				<string>BA99F75B86D32E8C1D12F5167359D6E2</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>9A1314F41D4AF302873CCAE4DF95096E</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>SwiftyJSON.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>9A590701475CDEC7488348815ADACCBC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
-				<string>64F09C054760D010B8E1B3BEB4671267</string>
-				<string>293CBC63DDF03144B25885047CA44A32</string>
-				<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
-				<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9BE8F84C840D474BB60E62D4A8259C63</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E6671F9532A947F40918CF9A0D44F70F</string>
-				<string>2A14E4E75C0921B8190FF7805BDB1994</string>
-				<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
-				<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
-				<string>0F0AD0445D068E37E1C8498A3BF6150D</string>
-				<string>6B923F40E09322629BC57536AFBDAB00</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/SwiftyJSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D3BE8B79BE19FBE664EBECF0B50D300</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Tests</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>9E350CCD50346BBEAD007279DA919999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2901A0000603C63521D4DED64D2B4586</string>
-				<string>DEC84C118AC1DA713A832BFDF21F45E2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9EADFEED37C12003F2FE470649EF5A49</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E7DD6469E226114253998E809F39BCD1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>A16806250A7E7DD443C4EDB15A117D0E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>7B7998CBFC4F64B40662D5BE2471EA16</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>A1B59F9DF18152F704FE8F577A69E455</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>A579A389F40ED521DC90FA82DA684595</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FF972453FA7F311A42163A996F627326</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>A96B9484D73AF99585C0F4500550DE5A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>155E3FCDB75DFDBB152E101B4C202295</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>AA8A7B051C0D58209033A2F69D3D1CBA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeClientDelegate.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEC58E9B2FE610C5D55CBB2FA4D34F2A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6E1FB52B709CB783F4109CA61174C28B</string>
-				<string>37D9B4C012C932EED434E89C515FA960</string>
-				<string>4471A15D81938B6C2CE6A161EC41FEED</string>
-				<string>B29C7FFE8D08A56E77C644C03000FC94</string>
-				<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
-				<string>14B7C4FE824293ABEEF592A7E71C4AFC</string>
-				<string>4885D84AE492246F7B92A35D5F4C2787</string>
-				<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
-				<string>B661AAF1FC01F5B9EB53567F4990C215</string>
-				<string>2692C5A026D6876DF0B8ED238232F2E6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-FayeSwift_Example</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B0F7AB6108413A1758B2F2D999AED350</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>17665D60312637FC3C2207AEFD337BAD</string>
-			<key>buildPhases</key>
-			<array>
-				<string>5CA1401B9C2AC9B84FD288DB6C3FC702</string>
-				<string>E307332C7150A001B3765B245D2D6839</string>
-				<string>22E6B7DDC8DADDE451326034FD9E9C8E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>050F3648989E5C1D6979F7A0EDAA352A</string>
-				<string>344AD1F5AB3B588C01B21778050F2EAF</string>
-				<string>5D1E5C8AB017A941ACA43B001D23BCFA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>productName</key>
-			<string>Pods-FayeSwift_Example</string>
-			<key>productReference</key>
-			<string>64F09C054760D010B8E1B3BEB4671267</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>B1C1530B6651528BC37303CE7401BF99</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-			<key>remoteInfo</key>
-			<string>FayeSwift</string>
-		</dict>
-		<key>B267AB921ABBC8B1A9D9D568D0D05615</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>SwiftyJSON.framework</string>
-			<key>path</key>
-			<string>SwiftyJSON.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B29C7FFE8D08A56E77C644C03000FC94</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B60722EF6A0F9DCD2D7C6D03F8B362CD</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>38A444149F18F886FD0A1E23B45D6671</string>
-				<string>87D64F48FA18233694918281C87E0266</string>
-				<string>57072CFE2F97B4E7645A18D9267BA425</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Starscream</string>
-			<key>path</key>
-			<string>Starscream</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B661AAF1FC01F5B9EB53567F4990C215</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Example.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B67F6FB5E88D459FDF1CC4FD93CB5D6B</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>FayeSwift.framework</string>
-			<key>path</key>
-			<string>FayeSwift.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B7098005E3463F71E30EE2ACC3981519</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B8D637FB9D47D77BBA1D7A37CE57E05F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>B93968102E7FD3EAE8BED45C989328EF</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Starscream/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Starscream/Starscream.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>Starscream</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>B98F1A78B8406D8DE50340A8632588E9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>Transport.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B9BD316B84610E564DEC11C4F736BD36</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>BA7367A9809BA19B15229BD6A97BF748</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0813DA1F91E6465D940389B245DB41E4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>BA99F75B86D32E8C1D12F5167359D6E2</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>4AB2D41C9043F185BD735AC2476F72C6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Tests</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>C05B711322CA076AB9A57512649A029E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>B661AAF1FC01F5B9EB53567F4990C215</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_FayeSwift_Example</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>C412C36AF79D03E0CB1D365F868D4F0B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeClient.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C56D3FE3F52A8D747E34473EF1315CF7</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>7FCD02EA8C46A7BE4F4C55DF12CEB124</string>
-			<key>buildPhases</key>
-			<array>
-				<string>EC58A33380EA9B37BB944B04C1F3AE53</string>
-				<string>0AC47F7781401C3893E4D44D51617586</string>
-				<string>F912B38D7469867C424F80F4C8770DEB</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>40CE25E3C0BCCCA4C2AF868C127EE751</string>
-				<string>F127B67BA9F6A72ECEF5BAD63C4F3BED</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>FayeSwift</string>
-			<key>productName</key>
-			<string>FayeSwift</string>
-			<key>productReference</key>
-			<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>CFB3E404A66EE13E14582416D200A72C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D26B5E2282A330BE919FE4EFDFB738B3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D41D8CD98F00B204E9800998ECF8427E</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastSwiftUpdateCheck</key>
-				<string>0700</string>
-				<key>LastUpgradeCheck</key>
-				<string>0700</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>7DB346D0F39D3F0E887471402A8071AB</string>
-			<key>productRefGroup</key>
-			<string>9A590701475CDEC7488348815ADACCBC</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
-				<string>B0F7AB6108413A1758B2F2D999AED350</string>
-				<string>259498FBDA923366A8452198A57D1F08</string>
-				<string>2FFB5CE6155C8F4095C8976A29498960</string>
-				<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			</array>
-		</dict>
-		<key>D47E6B74B427A4904D75990D1C34E829</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Starscream-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D4E1B392E0B7E62D774C23D5F31E2CEC</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F9256BA24236127F4EA11F8A1F99C6DF</string>
-				<string>BA7367A9809BA19B15229BD6A97BF748</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>D5A61BB662B60E80642A24E32724275E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C6718FA411202146721CBD6539BA6A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D7AD1CA221F811429F2397EA408725EE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1DCE2224000629085D044E4A5FDB2710</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DEC84C118AC1DA713A832BFDF21F45E2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2D9BE4E9101DCFEEF862D023F09073FA</string>
-				<string>8128B73B46CE4E130156947FEA792793</string>
-				<string>FF972453FA7F311A42163A996F627326</string>
-				<string>EB7D54C397F58433A25DA043B2ED90B3</string>
-				<string>155E3FCDB75DFDBB152E101B4C202295</string>
-				<string>86074C31635E6527FE9EB5D3D6DE479B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Example/Pods/Target Support Files/FayeSwift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E307332C7150A001B3765B245D2D6839</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>968A19F12E6EEAFE1AF4E01F94F08D05</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E4E07C18061452192A8755C57422BE93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E52013BD1A2AEE87A4182D2DEFAD6C4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>61F102DBDE488931620E8AA49183513B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>E641FD10F82298D81E564BF16487B827</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>remoteInfo</key>
-			<string>SwiftyJSON</string>
-		</dict>
-		<key>E6671F9532A947F40918CF9A0D44F70F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E7DD6469E226114253998E809F39BCD1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E83328805FF2933A2C3CEF374AFC4887</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>FayeSubscriptionModel.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EB7D54C397F58433A25DA043B2ED90B3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>FayeSwift-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC58A33380EA9B37BB944B04C1F3AE53</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>49EE77FDD417AD6D8551E84B667F057D</string>
-				<string>284F69195E7B74EADDB82148FD5DC647</string>
-				<string>143405C094ED81774A475A1A942BA220</string>
-				<string>A579A389F40ED521DC90FA82DA684595</string>
-				<string>7F7A42B67F6F0E9E305772EB90285630</string>
-				<string>E52013BD1A2AEE87A4182D2DEFAD6C4C</string>
-				<string>786D4D05CB5776378133906FD2A40DE6</string>
-				<string>F2114CECEB4EB16988736CE300F5ADDC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>ED0A84AABA966E6DE908E1D84ABB429E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Starscream.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F01BE1D9270805A4A53EB2B5924A139E</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>0AEC95D7E93685709B9C6A5B00BDDEB7</string>
-			<key>buildPhases</key>
-			<array>
-				<string>D4E1B392E0B7E62D774C23D5F31E2CEC</string>
-				<string>9EADFEED37C12003F2FE470649EF5A49</string>
-				<string>A16806250A7E7DD443C4EDB15A117D0E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>productName</key>
-			<string>SwiftyJSON</string>
-			<key>productReference</key>
-			<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>F127B67BA9F6A72ECEF5BAD63C4F3BED</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>SwiftyJSON</string>
-			<key>target</key>
-			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
-			<key>targetProxy</key>
-			<string>5171549988DEFF7760E6073814FFA524</string>
-		</dict>
-		<key>F2114CECEB4EB16988736CE300F5ADDC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
-			</dict>
-		</dict>
-		<key>F2F5FF28F679ADC8A92B329DFCDCE51F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>D7AD1CA221F811429F2397EA408725EE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F3FCAA0DF279AAE5F2E8878F0749DD44</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-FayeSwift_Tests.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F912B38D7469867C424F80F4C8770DEB</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>A96B9484D73AF99585C0F4500550DE5A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F9256BA24236127F4EA11F8A1F99C6DF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FB45FFD90572718D82AB9092B750F0CA</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>FB4DED77D2E4800415AEB7F77228E2A1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8128B73B46CE4E130156947FEA792793</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/FayeSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>FayeSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>FF972453FA7F311A42163A996F627326</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>FayeSwift-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>D41D8CD98F00B204E9800998ECF8427E</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		143405C094ED81774A475A1A942BA220 /* FayeSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		18B303F193AF762CF2DBE56F6B24B5CE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		284F69195E7B74EADDB82148FD5DC647 /* FayeClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		49EE77FDD417AD6D8551E84B667F057D /* FayeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		548BDBC634056C39A523C64AB1870D93 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A3750120EFC5FE7B1FF72E6AE18A998 /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EA65666CE5344D192D5B67A85CAFA39 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		704BC00CA3D5CF10EF09C356B799A500 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */; };
+		786D4D05CB5776378133906FD2A40DE6 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7B7998CBFC4F64B40662D5BE2471EA16 /* SwiftyJSON-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F7A42B67F6F0E9E305772EB90285630 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */; };
+		957ADEE6257BB32E03F9E872F76D3479 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
+		968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		A579A389F40ED521DC90FA82DA684595 /* FayeSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */; };
+		A96B9484D73AF99585C0F4500550DE5A /* FayeSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B7098005E3463F71E30EE2ACC3981519 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		BA7367A9809BA19B15229BD6A97BF748 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D5A61BB662B60E80642A24E32724275E /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
+		D5F070071D3E745500594A5D /* FayeClient+Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F070061D3E745500594A5D /* FayeClient+Transport.swift */; };
+		D5F070091D3E75D700594A5D /* FayeClient+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F070081D3E75D700594A5D /* FayeClient+Parsing.swift */; };
+		D5F0700B1D3E767200594A5D /* FayeClient+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0700A1D3E767200594A5D /* FayeClient+Action.swift */; };
+		D5F0700D1D3E76F300594A5D /* FayeClient+Bayuex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0700C1D3E76F300594A5D /* FayeClient+Bayuex.swift */; };
+		D5F0700F1D3E782200594A5D /* FayeClient+Subscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0700E1D3E782200594A5D /* FayeClient+Subscriptions.swift */; };
+		D5F070111D3E78C100594A5D /* FayeClient+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F070101D3E78C100594A5D /* FayeClient+Helper.swift */; };
+		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
+		E52013BD1A2AEE87A4182D2DEFAD6C4C /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E7DD6469E226114253998E809F39BCD1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
+		F2114CECEB4EB16988736CE300F5ADDC /* WebsocketTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F9256BA24236127F4EA11F8A1F99C6DF /* SwiftyJSON-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
+			remoteInfo = Starscream;
+		};
+		5171549988DEFF7760E6073814FFA524 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
+			remoteInfo = SwiftyJSON;
+		};
+		6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C56D3FE3F52A8D747E34473EF1315CF7;
+			remoteInfo = FayeSwift;
+		};
+		85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
+			remoteInfo = Starscream;
+		};
+		88B85D4B1942F047C1DC470C922B7703 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
+			remoteInfo = Starscream;
+		};
+		A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
+			remoteInfo = SwiftyJSON;
+		};
+		B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C56D3FE3F52A8D747E34473EF1315CF7;
+			remoteInfo = FayeSwift;
+		};
+		E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
+			remoteInfo = SwiftyJSON;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Example-umbrella.h"; sourceTree = "<group>"; };
+		0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
+		0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
+		10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Tests-umbrella.h"; sourceTree = "<group>"; };
+		14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-frameworks.sh"; sourceTree = "<group>"; };
+		154C747E02B1DCBD4885645B5878477F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-umbrella.h"; sourceTree = "<group>"; };
+		15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Starscream-dummy.m"; sourceTree = "<group>"; };
+		1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Tests-dummy.m"; sourceTree = "<group>"; };
+		1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
+		2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
+		293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
+		2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		2D9BE4E9101DCFEEF862D023F09073FA /* FayeSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = FayeSwift.modulemap; sourceTree = "<group>"; };
+		2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Example-dummy.m"; sourceTree = "<group>"; };
+		37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Example.modulemap"; sourceTree = "<group>"; };
+		38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Source/SSLSecurity.swift; sourceTree = "<group>"; };
+		3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-prefix.pch"; sourceTree = "<group>"; };
+		47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.xcconfig; sourceTree = "<group>"; };
+		487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Helper.swift"; sourceTree = "<group>"; };
+		4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-resources.sh"; sourceTree = "<group>"; };
+		4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebsocketTransport.swift; sourceTree = "<group>"; };
+		64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
+		6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftyJSON-dummy.m"; sourceTree = "<group>"; };
+		6E1FB52B709CB783F4109CA61174C28B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FayeSwift.xcconfig; sourceTree = "<group>"; };
+		86074C31635E6527FE9EB5D3D6DE479B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		87D64F48FA18233694918281C87E0266 /* WebSocket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Source/WebSocket.swift; sourceTree = "<group>"; };
+		9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClientDelegate.swift; sourceTree = "<group>"; };
+		B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FayeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-resources.sh"; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
+		CFB3E404A66EE13E14582416D200A72C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
+		D5F070061D3E745500594A5D /* FayeClient+Transport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FayeClient+Transport.swift"; sourceTree = "<group>"; };
+		D5F070081D3E75D700594A5D /* FayeClient+Parsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FayeClient+Parsing.swift"; sourceTree = "<group>"; };
+		D5F0700A1D3E767200594A5D /* FayeClient+Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FayeClient+Action.swift"; sourceTree = "<group>"; };
+		D5F0700C1D3E76F300594A5D /* FayeClient+Bayuex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FayeClient+Bayuex.swift"; sourceTree = "<group>"; };
+		D5F0700E1D3E782200594A5D /* FayeClient+Subscriptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FayeClient+Subscriptions.swift"; sourceTree = "<group>"; };
+		D5F070101D3E78C100594A5D /* FayeClient+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FayeClient+Helper.swift"; sourceTree = "<group>"; };
+		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeSubscriptionModel.swift; sourceTree = "<group>"; };
+		EB7D54C397F58433A25DA043B2ED90B3 /* FayeSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-prefix.pch"; sourceTree = "<group>"; };
+		ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Starscream.modulemap; sourceTree = "<group>"; };
+		F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Tests.modulemap"; sourceTree = "<group>"; };
+		FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0AC47F7781401C3893E4D44D51617586 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				18B303F193AF762CF2DBE56F6B24B5CE /* Foundation.framework in Frameworks */,
+				957ADEE6257BB32E03F9E872F76D3479 /* Starscream.framework in Frameworks */,
+				704BC00CA3D5CF10EF09C356B799A500 /* SwiftyJSON.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0E62CB0F51CFEF3EF98705FE6ED1BAA1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B7098005E3463F71E30EE2ACC3981519 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EADFEED37C12003F2FE470649EF5A49 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7DD6469E226114253998E809F39BCD1 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E307332C7150A001B3765B245D2D6839 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */,
+				0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				154C747E02B1DCBD4885645B5878477F /* Info.plist */,
+				F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */,
+				2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */,
+				15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */,
+				1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */,
+				E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */,
+				B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */,
+				10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */,
+				D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */,
+				4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */,
+			);
+			name = "Pods-FayeSwift_Tests";
+			path = "Target Support Files/Pods-FayeSwift_Tests";
+			sourceTree = "<group>";
+		};
+		0C03422930E80D7BB92C5C859589F09F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */,
+				48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */,
+				9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */,
+				4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9E350CCD50346BBEAD007279DA919999 /* FayeSwift */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		2901A0000603C63521D4DED64D2B4586 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				D5F070011D3E73E400594A5D /* client */,
+				D5F070041D3E740000594A5D /* transport */,
+				D5F070021D3E73EB00594A5D /* model */,
+				D5F070031D3E73F200594A5D /* helper */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */ = {
+			isa = PBXGroup;
+			children = (
+				0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */,
+				9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */,
+			);
+			path = SwiftyJSON;
+			sourceTree = "<group>";
+		};
+		4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		57072CFE2F97B4E7645A18D9267BA425 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				CFB3E404A66EE13E14582416D200A72C /* Info.plist */,
+				ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */,
+				47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */,
+				18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */,
+				47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */,
+				D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Starscream";
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */,
+				0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */,
+				0C03422930E80D7BB92C5C859589F09F /* Pods */,
+				9A590701475CDEC7488348815ADACCBC /* Products */,
+				000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		9A590701475CDEC7488348815ADACCBC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */,
+				64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */,
+				293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */,
+				9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */,
+				B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E6671F9532A947F40918CF9A0D44F70F /* Info.plist */,
+				2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */,
+				1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */,
+				6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */,
+				0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */,
+				6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/SwiftyJSON";
+			sourceTree = "<group>";
+		};
+		9E350CCD50346BBEAD007279DA919999 /* FayeSwift */ = {
+			isa = PBXGroup;
+			children = (
+				2901A0000603C63521D4DED64D2B4586 /* Sources */,
+				DEC84C118AC1DA713A832BFDF21F45E2 /* Support Files */,
+			);
+			name = FayeSwift;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */ = {
+			isa = PBXGroup;
+			children = (
+				6E1FB52B709CB783F4109CA61174C28B /* Info.plist */,
+				37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */,
+				4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */,
+				B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */,
+				2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */,
+				14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */,
+				4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */,
+				06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */,
+				B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */,
+				2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */,
+			);
+			name = "Pods-FayeSwift_Example";
+			path = "Target Support Files/Pods-FayeSwift_Example";
+			sourceTree = "<group>";
+		};
+		B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */ = {
+			isa = PBXGroup;
+			children = (
+				38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */,
+				87D64F48FA18233694918281C87E0266 /* WebSocket.swift */,
+				57072CFE2F97B4E7645A18D9267BA425 /* Support Files */,
+			);
+			path = Starscream;
+			sourceTree = "<group>";
+		};
+		D5F070011D3E73E400594A5D /* client */ = {
+			isa = PBXGroup;
+			children = (
+				C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */,
+				D5F070101D3E78C100594A5D /* FayeClient+Helper.swift */,
+				D5F0700E1D3E782200594A5D /* FayeClient+Subscriptions.swift */,
+				D5F0700C1D3E76F300594A5D /* FayeClient+Bayuex.swift */,
+				D5F0700A1D3E767200594A5D /* FayeClient+Action.swift */,
+				D5F070081D3E75D700594A5D /* FayeClient+Parsing.swift */,
+				D5F070061D3E745500594A5D /* FayeClient+Transport.swift */,
+				AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */,
+			);
+			name = client;
+			sourceTree = "<group>";
+		};
+		D5F070021D3E73EB00594A5D /* model */ = {
+			isa = PBXGroup;
+			children = (
+				E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */,
+			);
+			name = model;
+			sourceTree = "<group>";
+		};
+		D5F070031D3E73F200594A5D /* helper */ = {
+			isa = PBXGroup;
+			children = (
+				487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */,
+				61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */,
+			);
+			name = helper;
+			sourceTree = "<group>";
+		};
+		D5F070041D3E740000594A5D /* transport */ = {
+			isa = PBXGroup;
+			children = (
+				D5F070051D3E741000594A5D /* websocket */,
+			);
+			name = transport;
+			sourceTree = "<group>";
+		};
+		D5F070051D3E741000594A5D /* websocket */ = {
+			isa = PBXGroup;
+			children = (
+				B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */,
+				62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */,
+			);
+			name = websocket;
+			sourceTree = "<group>";
+		};
+		DEC84C118AC1DA713A832BFDF21F45E2 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				2D9BE4E9101DCFEEF862D023F09073FA /* FayeSwift.modulemap */,
+				8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */,
+				FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */,
+				EB7D54C397F58433A25DA043B2ED90B3 /* FayeSwift-prefix.pch */,
+				155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */,
+				86074C31635E6527FE9EB5D3D6DE479B /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/FayeSwift";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0C93A0CF1060B47E24A8905CE9F33ED1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5A3750120EFC5FE7B1FF72E6AE18A998 /* Starscream-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A16806250A7E7DD443C4EDB15A117D0E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7B7998CBFC4F64B40662D5BE2471EA16 /* SwiftyJSON-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F912B38D7469867C424F80F4C8770DEB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A96B9484D73AF99585C0F4500550DE5A /* FayeSwift-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */;
+			buildPhases = (
+				F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */,
+				1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */,
+				74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */,
+				396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */,
+				743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */,
+			);
+			name = "Pods-FayeSwift_Tests";
+			productName = "Pods-FayeSwift_Tests";
+			productReference = 293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2FFB5CE6155C8F4095C8976A29498960 /* Starscream */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EEFF32D5BCC2D64205AA37299BC9746 /* Build configuration list for PBXNativeTarget "Starscream" */;
+			buildPhases = (
+				08C9E34BFE3CE6E33FB4863BF08E5C1B /* Sources */,
+				0E62CB0F51CFEF3EF98705FE6ED1BAA1 /* Frameworks */,
+				0C93A0CF1060B47E24A8905CE9F33ED1 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Starscream;
+			productName = Starscream;
+			productReference = 9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */;
+			buildPhases = (
+				5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */,
+				E307332C7150A001B3765B245D2D6839 /* Frameworks */,
+				22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */,
+				344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */,
+				5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */,
+			);
+			name = "Pods-FayeSwift_Example";
+			productName = "Pods-FayeSwift_Example";
+			productReference = 64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7FCD02EA8C46A7BE4F4C55DF12CEB124 /* Build configuration list for PBXNativeTarget "FayeSwift" */;
+			buildPhases = (
+				EC58A33380EA9B37BB944B04C1F3AE53 /* Sources */,
+				0AC47F7781401C3893E4D44D51617586 /* Frameworks */,
+				F912B38D7469867C424F80F4C8770DEB /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				40CE25E3C0BCCCA4C2AF868C127EE751 /* PBXTargetDependency */,
+				F127B67BA9F6A72ECEF5BAD63C4F3BED /* PBXTargetDependency */,
+			);
+			name = FayeSwift;
+			productName = FayeSwift;
+			productReference = B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0AEC95D7E93685709B9C6A5B00BDDEB7 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
+			buildPhases = (
+				D4E1B392E0B7E62D774C23D5F31E2CEC /* Sources */,
+				9EADFEED37C12003F2FE470649EF5A49 /* Frameworks */,
+				A16806250A7E7DD443C4EDB15A117D0E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftyJSON;
+			productName = SwiftyJSON;
+			productReference = B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
+			};
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 9A590701475CDEC7488348815ADACCBC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */,
+				B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */,
+				259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */,
+				2FFB5CE6155C8F4095C8976A29498960 /* Starscream */,
+				F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		08C9E34BFE3CE6E33FB4863BF08E5C1B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5EA65666CE5344D192D5B67A85CAFA39 /* SSLSecurity.swift in Sources */,
+				D5A61BB662B60E80642A24E32724275E /* Starscream-dummy.m in Sources */,
+				548BDBC634056C39A523C64AB1870D93 /* WebSocket.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D4E1B392E0B7E62D774C23D5F31E2CEC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F9256BA24236127F4EA11F8A1F99C6DF /* SwiftyJSON-dummy.m in Sources */,
+				BA7367A9809BA19B15229BD6A97BF748 /* SwiftyJSON.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC58A33380EA9B37BB944B04C1F3AE53 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D5F0700F1D3E782200594A5D /* FayeClient+Subscriptions.swift in Sources */,
+				49EE77FDD417AD6D8551E84B667F057D /* FayeClient.swift in Sources */,
+				284F69195E7B74EADDB82148FD5DC647 /* FayeClientDelegate.swift in Sources */,
+				143405C094ED81774A475A1A942BA220 /* FayeSubscriptionModel.swift in Sources */,
+				D5F0700D1D3E76F300594A5D /* FayeClient+Bayuex.swift in Sources */,
+				D5F070071D3E745500594A5D /* FayeClient+Transport.swift in Sources */,
+				A579A389F40ED521DC90FA82DA684595 /* FayeSwift-dummy.m in Sources */,
+				7F7A42B67F6F0E9E305772EB90285630 /* NSError+Helper.swift in Sources */,
+				D5F0700B1D3E767200594A5D /* FayeClient+Action.swift in Sources */,
+				D5F070091D3E75D700594A5D /* FayeClient+Parsing.swift in Sources */,
+				E52013BD1A2AEE87A4182D2DEFAD6C4C /* StringExtensions.swift in Sources */,
+				D5F070111D3E78C100594A5D /* FayeClient+Helper.swift in Sources */,
+				786D4D05CB5776378133906FD2A40DE6 /* Transport.swift in Sources */,
+				F2114CECEB4EB16988736CE300F5ADDC /* WebsocketTransport.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FayeSwift;
+			target = C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */;
+			targetProxy = 6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */;
+		};
+		344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
+			targetProxy = 85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */;
+		};
+		396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
+			targetProxy = 252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */;
+		};
+		40CE25E3C0BCCCA4C2AF868C127EE751 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Starscream;
+			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
+			targetProxy = 88B85D4B1942F047C1DC470C922B7703 /* PBXContainerItemProxy */;
+		};
+		48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FayeSwift;
+			target = C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */;
+			targetProxy = B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */;
+		};
+		5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
+			targetProxy = E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */;
+		};
+		743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
+			targetProxy = A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */;
+		};
+		F127B67BA9F6A72ECEF5BAD63C4F3BED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftyJSON;
+			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
+			targetProxy = 5171549988DEFF7760E6073814FFA524 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0BF6F830DDC0BFF42803E165FB1B2621 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1FACCE2E2A3269AA6618DC62E86A5B78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = FayeSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3434E7FC44AEA830A2C6B752B26BCE33 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SwiftyJSON;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6C0CE301D9536F43B5C8E08E16712E38 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		82721887C459F67368E0CF06D91C7E57 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Starscream;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		B93968102E7FD3EAE8BED45C989328EF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Starscream;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BA99F75B86D32E8C1D12F5167359D6E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C05B711322CA076AB9A57512649A029E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_FayeSwift_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		FB4DED77D2E4800415AEB7F77228E2A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = FayeSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0AEC95D7E93685709B9C6A5B00BDDEB7 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3434E7FC44AEA830A2C6B752B26BCE33 /* Debug */,
+				0BF6F830DDC0BFF42803E165FB1B2621 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C05B711322CA076AB9A57512649A029E /* Debug */,
+				6C0CE301D9536F43B5C8E08E16712E38 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
+				FB45FFD90572718D82AB9092B750F0CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3EEFF32D5BCC2D64205AA37299BC9746 /* Build configuration list for PBXNativeTarget "Starscream" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B93968102E7FD3EAE8BED45C989328EF /* Debug */,
+				82721887C459F67368E0CF06D91C7E57 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7FCD02EA8C46A7BE4F4C55DF12CEB124 /* Build configuration list for PBXNativeTarget "FayeSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FACCE2E2A3269AA6618DC62E86A5B78 /* Debug */,
+				FB4DED77D2E4800415AEB7F77228E2A1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */,
+				BA99F75B86D32E8C1D12F5167359D6E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+}

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,1119 +1,2718 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		143405C094ED81774A475A1A942BA220 /* FayeSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		18B303F193AF762CF2DBE56F6B24B5CE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		284F69195E7B74EADDB82148FD5DC647 /* FayeClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		49EE77FDD417AD6D8551E84B667F057D /* FayeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		548BDBC634056C39A523C64AB1870D93 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A3750120EFC5FE7B1FF72E6AE18A998 /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5EA65666CE5344D192D5B67A85CAFA39 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		704BC00CA3D5CF10EF09C356B799A500 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */; };
-		786D4D05CB5776378133906FD2A40DE6 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7B7998CBFC4F64B40662D5BE2471EA16 /* SwiftyJSON-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F7A42B67F6F0E9E305772EB90285630 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */; };
-		957ADEE6257BB32E03F9E872F76D3479 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
-		968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		A579A389F40ED521DC90FA82DA684595 /* FayeSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */; };
-		A96B9484D73AF99585C0F4500550DE5A /* FayeSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B7098005E3463F71E30EE2ACC3981519 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		BA7367A9809BA19B15229BD6A97BF748 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D5A61BB662B60E80642A24E32724275E /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
-		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
-		E52013BD1A2AEE87A4182D2DEFAD6C4C /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E7DD6469E226114253998E809F39BCD1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		F2114CECEB4EB16988736CE300F5ADDC /* WebsocketTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F9256BA24236127F4EA11F8A1F99C6DF /* SwiftyJSON-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
-			remoteInfo = Starscream;
-		};
-		5171549988DEFF7760E6073814FFA524 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
-			remoteInfo = SwiftyJSON;
-		};
-		6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C56D3FE3F52A8D747E34473EF1315CF7;
-			remoteInfo = FayeSwift;
-		};
-		85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
-			remoteInfo = Starscream;
-		};
-		88B85D4B1942F047C1DC470C922B7703 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2FFB5CE6155C8F4095C8976A29498960;
-			remoteInfo = Starscream;
-		};
-		A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
-			remoteInfo = SwiftyJSON;
-		};
-		B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C56D3FE3F52A8D747E34473EF1315CF7;
-			remoteInfo = FayeSwift;
-		};
-		E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F01BE1D9270805A4A53EB2B5924A139E;
-			remoteInfo = SwiftyJSON;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Example-umbrella.h"; sourceTree = "<group>"; };
-		0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
-		0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
-		10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Tests-umbrella.h"; sourceTree = "<group>"; };
-		14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-frameworks.sh"; sourceTree = "<group>"; };
-		154C747E02B1DCBD4885645B5878477F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-umbrella.h"; sourceTree = "<group>"; };
-		15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Starscream-dummy.m"; sourceTree = "<group>"; };
-		1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Tests-dummy.m"; sourceTree = "<group>"; };
-		1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
-		2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
-		293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
-		2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		2D9BE4E9101DCFEEF862D023F09073FA /* FayeSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = FayeSwift.modulemap; sourceTree = "<group>"; };
-		2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Example-dummy.m"; sourceTree = "<group>"; };
-		37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Example.modulemap"; sourceTree = "<group>"; };
-		38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Source/SSLSecurity.swift; sourceTree = "<group>"; };
-		3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-prefix.pch"; sourceTree = "<group>"; };
-		47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.xcconfig; sourceTree = "<group>"; };
-		487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Helper.swift"; sourceTree = "<group>"; };
-		4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-resources.sh"; sourceTree = "<group>"; };
-		4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
-		62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebsocketTransport.swift; sourceTree = "<group>"; };
-		64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
-		6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftyJSON-dummy.m"; sourceTree = "<group>"; };
-		6E1FB52B709CB783F4109CA61174C28B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FayeSwift.xcconfig; sourceTree = "<group>"; };
-		86074C31635E6527FE9EB5D3D6DE479B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		87D64F48FA18233694918281C87E0266 /* WebSocket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Source/WebSocket.swift; sourceTree = "<group>"; };
-		9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClientDelegate.swift; sourceTree = "<group>"; };
-		B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FayeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
-		B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-resources.sh"; sourceTree = "<group>"; };
-		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
-		CFB3E404A66EE13E14582416D200A72C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
-		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeSubscriptionModel.swift; sourceTree = "<group>"; };
-		EB7D54C397F58433A25DA043B2ED90B3 /* FayeSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-prefix.pch"; sourceTree = "<group>"; };
-		ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Starscream.modulemap; sourceTree = "<group>"; };
-		F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Tests.modulemap"; sourceTree = "<group>"; };
-		FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		0AC47F7781401C3893E4D44D51617586 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				18B303F193AF762CF2DBE56F6B24B5CE /* Foundation.framework in Frameworks */,
-				957ADEE6257BB32E03F9E872F76D3479 /* Starscream.framework in Frameworks */,
-				704BC00CA3D5CF10EF09C356B799A500 /* SwiftyJSON.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0E62CB0F51CFEF3EF98705FE6ED1BAA1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B7098005E3463F71E30EE2ACC3981519 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9EADFEED37C12003F2FE470649EF5A49 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E7DD6469E226114253998E809F39BCD1 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E307332C7150A001B3765B245D2D6839 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */,
-				0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */ = {
-			isa = PBXGroup;
-			children = (
-				154C747E02B1DCBD4885645B5878477F /* Info.plist */,
-				F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */,
-				2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */,
-				15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */,
-				1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */,
-				E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */,
-				B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */,
-				10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */,
-				D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */,
-				4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */,
-			);
-			name = "Pods-FayeSwift_Tests";
-			path = "Target Support Files/Pods-FayeSwift_Tests";
-			sourceTree = "<group>";
-		};
-		0C03422930E80D7BB92C5C859589F09F /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */,
-				48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */,
-				9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */,
-				4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				9E350CCD50346BBEAD007279DA919999 /* FayeSwift */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		2901A0000603C63521D4DED64D2B4586 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				D59521FF1D2E5F8300BB1F1B /* client */,
-				D59521FC1D2E5F6300BB1F1B /* model */,
-				D59521FD1D2E5F6900BB1F1B /* helper */,
-				D59521FE1D2E5F7400BB1F1B /* transport */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */ = {
-			isa = PBXGroup;
-			children = (
-				0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */,
-				9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */,
-			);
-			path = SwiftyJSON;
-			sourceTree = "<group>";
-		};
-		4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		57072CFE2F97B4E7645A18D9267BA425 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CFB3E404A66EE13E14582416D200A72C /* Info.plist */,
-				ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */,
-				47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */,
-				18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */,
-				47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */,
-				D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Starscream";
-			sourceTree = "<group>";
-		};
-		7DB346D0F39D3F0E887471402A8071AB = {
-			isa = PBXGroup;
-			children = (
-				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
-				1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */,
-				0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */,
-				0C03422930E80D7BB92C5C859589F09F /* Pods */,
-				9A590701475CDEC7488348815ADACCBC /* Products */,
-				000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		9A590701475CDEC7488348815ADACCBC /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */,
-				64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */,
-				293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */,
-				9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */,
-				B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E6671F9532A947F40918CF9A0D44F70F /* Info.plist */,
-				2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */,
-				1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */,
-				6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */,
-				0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */,
-				6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftyJSON";
-			sourceTree = "<group>";
-		};
-		9E350CCD50346BBEAD007279DA919999 /* FayeSwift */ = {
-			isa = PBXGroup;
-			children = (
-				2901A0000603C63521D4DED64D2B4586 /* Sources */,
-				DEC84C118AC1DA713A832BFDF21F45E2 /* Support Files */,
-			);
-			name = FayeSwift;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */ = {
-			isa = PBXGroup;
-			children = (
-				6E1FB52B709CB783F4109CA61174C28B /* Info.plist */,
-				37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */,
-				4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */,
-				B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */,
-				2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */,
-				14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */,
-				4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */,
-				06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */,
-				B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */,
-				2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */,
-			);
-			name = "Pods-FayeSwift_Example";
-			path = "Target Support Files/Pods-FayeSwift_Example";
-			sourceTree = "<group>";
-		};
-		B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */ = {
-			isa = PBXGroup;
-			children = (
-				38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */,
-				87D64F48FA18233694918281C87E0266 /* WebSocket.swift */,
-				57072CFE2F97B4E7645A18D9267BA425 /* Support Files */,
-			);
-			path = Starscream;
-			sourceTree = "<group>";
-		};
-		D59521FC1D2E5F6300BB1F1B /* model */ = {
-			isa = PBXGroup;
-			children = (
-				E83328805FF2933A2C3CEF374AFC4887 /* FayeSubscriptionModel.swift */,
-			);
-			name = model;
-			sourceTree = "<group>";
-		};
-		D59521FD1D2E5F6900BB1F1B /* helper */ = {
-			isa = PBXGroup;
-			children = (
-				487A65235BC761C63EA749D3504478B5 /* NSError+Helper.swift */,
-				61F102DBDE488931620E8AA49183513B /* StringExtensions.swift */,
-			);
-			name = helper;
-			sourceTree = "<group>";
-		};
-		D59521FE1D2E5F7400BB1F1B /* transport */ = {
-			isa = PBXGroup;
-			children = (
-				B98F1A78B8406D8DE50340A8632588E9 /* Transport.swift */,
-				62E2EDCCDEE8B32C1115DA2D9C6361CC /* WebsocketTransport.swift */,
-			);
-			name = transport;
-			sourceTree = "<group>";
-		};
-		D59521FF1D2E5F8300BB1F1B /* client */ = {
-			isa = PBXGroup;
-			children = (
-				C412C36AF79D03E0CB1D365F868D4F0B /* FayeClient.swift */,
-				AA8A7B051C0D58209033A2F69D3D1CBA /* FayeClientDelegate.swift */,
-			);
-			name = client;
-			sourceTree = "<group>";
-		};
-		DEC84C118AC1DA713A832BFDF21F45E2 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				2D9BE4E9101DCFEEF862D023F09073FA /* FayeSwift.modulemap */,
-				8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */,
-				FF972453FA7F311A42163A996F627326 /* FayeSwift-dummy.m */,
-				EB7D54C397F58433A25DA043B2ED90B3 /* FayeSwift-prefix.pch */,
-				155E3FCDB75DFDBB152E101B4C202295 /* FayeSwift-umbrella.h */,
-				86074C31635E6527FE9EB5D3D6DE479B /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/FayeSwift";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		0C93A0CF1060B47E24A8905CE9F33ED1 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5A3750120EFC5FE7B1FF72E6AE18A998 /* Starscream-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A16806250A7E7DD443C4EDB15A117D0E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7B7998CBFC4F64B40662D5BE2471EA16 /* SwiftyJSON-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F912B38D7469867C424F80F4C8770DEB /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A96B9484D73AF99585C0F4500550DE5A /* FayeSwift-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */;
-			buildPhases = (
-				F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */,
-				1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */,
-				74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */,
-				396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */,
-				743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */,
-			);
-			name = "Pods-FayeSwift_Tests";
-			productName = "Pods-FayeSwift_Tests";
-			productReference = 293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		2FFB5CE6155C8F4095C8976A29498960 /* Starscream */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 3EEFF32D5BCC2D64205AA37299BC9746 /* Build configuration list for PBXNativeTarget "Starscream" */;
-			buildPhases = (
-				08C9E34BFE3CE6E33FB4863BF08E5C1B /* Sources */,
-				0E62CB0F51CFEF3EF98705FE6ED1BAA1 /* Frameworks */,
-				0C93A0CF1060B47E24A8905CE9F33ED1 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Starscream;
-			productName = Starscream;
-			productReference = 9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */;
-			buildPhases = (
-				5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */,
-				E307332C7150A001B3765B245D2D6839 /* Frameworks */,
-				22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */,
-				344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */,
-				5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */,
-			);
-			name = "Pods-FayeSwift_Example";
-			productName = "Pods-FayeSwift_Example";
-			productReference = 64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7FCD02EA8C46A7BE4F4C55DF12CEB124 /* Build configuration list for PBXNativeTarget "FayeSwift" */;
-			buildPhases = (
-				EC58A33380EA9B37BB944B04C1F3AE53 /* Sources */,
-				0AC47F7781401C3893E4D44D51617586 /* Frameworks */,
-				F912B38D7469867C424F80F4C8770DEB /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				40CE25E3C0BCCCA4C2AF868C127EE751 /* PBXTargetDependency */,
-				F127B67BA9F6A72ECEF5BAD63C4F3BED /* PBXTargetDependency */,
-			);
-			name = FayeSwift;
-			productName = FayeSwift;
-			productReference = B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0AEC95D7E93685709B9C6A5B00BDDEB7 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
-			buildPhases = (
-				D4E1B392E0B7E62D774C23D5F31E2CEC /* Sources */,
-				9EADFEED37C12003F2FE470649EF5A49 /* Frameworks */,
-				A16806250A7E7DD443C4EDB15A117D0E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftyJSON;
-			productName = SwiftyJSON;
-			productReference = B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
-			};
-			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 9A590701475CDEC7488348815ADACCBC /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */,
-				B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */,
-				259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */,
-				2FFB5CE6155C8F4095C8976A29498960 /* Starscream */,
-				F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		08C9E34BFE3CE6E33FB4863BF08E5C1B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5EA65666CE5344D192D5B67A85CAFA39 /* SSLSecurity.swift in Sources */,
-				D5A61BB662B60E80642A24E32724275E /* Starscream-dummy.m in Sources */,
-				548BDBC634056C39A523C64AB1870D93 /* WebSocket.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D4E1B392E0B7E62D774C23D5F31E2CEC /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F9256BA24236127F4EA11F8A1F99C6DF /* SwiftyJSON-dummy.m in Sources */,
-				BA7367A9809BA19B15229BD6A97BF748 /* SwiftyJSON.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EC58A33380EA9B37BB944B04C1F3AE53 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				49EE77FDD417AD6D8551E84B667F057D /* FayeClient.swift in Sources */,
-				284F69195E7B74EADDB82148FD5DC647 /* FayeClientDelegate.swift in Sources */,
-				143405C094ED81774A475A1A942BA220 /* FayeSubscriptionModel.swift in Sources */,
-				A579A389F40ED521DC90FA82DA684595 /* FayeSwift-dummy.m in Sources */,
-				7F7A42B67F6F0E9E305772EB90285630 /* NSError+Helper.swift in Sources */,
-				E52013BD1A2AEE87A4182D2DEFAD6C4C /* StringExtensions.swift in Sources */,
-				786D4D05CB5776378133906FD2A40DE6 /* Transport.swift in Sources */,
-				F2114CECEB4EB16988736CE300F5ADDC /* WebsocketTransport.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FayeSwift;
-			target = C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */;
-			targetProxy = 6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */;
-		};
-		344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
-			targetProxy = 85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */;
-		};
-		396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
-			targetProxy = 252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */;
-		};
-		40CE25E3C0BCCCA4C2AF868C127EE751 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = 2FFB5CE6155C8F4095C8976A29498960 /* Starscream */;
-			targetProxy = 88B85D4B1942F047C1DC470C922B7703 /* PBXContainerItemProxy */;
-		};
-		48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FayeSwift;
-			target = C56D3FE3F52A8D747E34473EF1315CF7 /* FayeSwift */;
-			targetProxy = B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */;
-		};
-		5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
-			targetProxy = E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */;
-		};
-		743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
-			targetProxy = A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */;
-		};
-		F127B67BA9F6A72ECEF5BAD63C4F3BED /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = F01BE1D9270805A4A53EB2B5924A139E /* SwiftyJSON */;
-			targetProxy = 5171549988DEFF7760E6073814FFA524 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		0BF6F830DDC0BFF42803E165FB1B2621 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		1FACCE2E2A3269AA6618DC62E86A5B78 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = FayeSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		3434E7FC44AEA830A2C6B752B26BCE33 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		6C0CE301D9536F43B5C8E08E16712E38 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		82721887C459F67368E0CF06D91C7E57 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Starscream;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				ONLY_ACTIVE_ARCH = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Debug;
-		};
-		B93968102E7FD3EAE8BED45C989328EF /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Starscream;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		BA99F75B86D32E8C1D12F5167359D6E2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		C05B711322CA076AB9A57512649A029E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		FB4DED77D2E4800415AEB7F77228E2A1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8128B73B46CE4E130156947FEA792793 /* FayeSwift.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = FayeSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		0AEC95D7E93685709B9C6A5B00BDDEB7 /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3434E7FC44AEA830A2C6B752B26BCE33 /* Debug */,
-				0BF6F830DDC0BFF42803E165FB1B2621 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C05B711322CA076AB9A57512649A029E /* Debug */,
-				6C0CE301D9536F43B5C8E08E16712E38 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
-				FB45FFD90572718D82AB9092B750F0CA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		3EEFF32D5BCC2D64205AA37299BC9746 /* Build configuration list for PBXNativeTarget "Starscream" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B93968102E7FD3EAE8BED45C989328EF /* Debug */,
-				82721887C459F67368E0CF06D91C7E57 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		7FCD02EA8C46A7BE4F4C55DF12CEB124 /* Build configuration list for PBXNativeTarget "FayeSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				1FACCE2E2A3269AA6618DC62E86A5B78 /* Debug */,
-				FB4DED77D2E4800415AEB7F77228E2A1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				9D3BE8B79BE19FBE664EBECF0B50D300 /* Debug */,
-				BA99F75B86D32E8C1D12F5167359D6E2 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>000A61D7F0D0221F20F470656F297E70</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>AEC58E9B2FE610C5D55CBB2FA4D34F2A</string>
+				<string>0A3C1A1DE210D08A1510BD9669BDF551</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Targets Support Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>050F3648989E5C1D6979F7A0EDAA352A</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>target</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>targetProxy</key>
+			<string>6CF3F2DD66CD874F21BF38ED13DD0295</string>
+		</dict>
+		<key>06B16C30B7CF62C246F4DD2B6BA325D2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0813DA1F91E6465D940389B245DB41E4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>SwiftyJSON.swift</string>
+			<key>path</key>
+			<string>Source/SwiftyJSON.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>08C9E34BFE3CE6E33FB4863BF08E5C1B</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>5EA65666CE5344D192D5B67A85CAFA39</string>
+				<string>D5A61BB662B60E80642A24E32724275E</string>
+				<string>548BDBC634056C39A523C64AB1870D93</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0A3C1A1DE210D08A1510BD9669BDF551</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>154C747E02B1DCBD4885645B5878477F</string>
+				<string>F3FCAA0DF279AAE5F2E8878F0749DD44</string>
+				<string>2D4EF06156597B9C0C9800347C3343FC</string>
+				<string>15765D47A6F3AC9E1A1D641D8B2ADB93</string>
+				<string>1DCE2224000629085D044E4A5FDB2710</string>
+				<string>E4E07C18061452192A8755C57422BE93</string>
+				<string>B9BD316B84610E564DEC11C4F736BD36</string>
+				<string>10E4A21EDDC41F94B30C17F38403E413</string>
+				<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
+				<string>4AB2D41C9043F185BD735AC2476F72C6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-FayeSwift_Tests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0A3C59C66401164839B33852471AF8AF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>0AC47F7781401C3893E4D44D51617586</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>18B303F193AF762CF2DBE56F6B24B5CE</string>
+				<string>957ADEE6257BB32E03F9E872F76D3479</string>
+				<string>704BC00CA3D5CF10EF09C356B799A500</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0AEC95D7E93685709B9C6A5B00BDDEB7</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>3434E7FC44AEA830A2C6B752B26BCE33</string>
+				<string>0BF6F830DDC0BFF42803E165FB1B2621</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>0BF6F830DDC0BFF42803E165FB1B2621</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SwiftyJSON/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>SwiftyJSON</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>0C03422930E80D7BB92C5C859589F09F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B60722EF6A0F9DCD2D7C6D03F8B362CD</string>
+				<string>48BC61B70DBB2FA057A57FF358488F76</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0C93A0CF1060B47E24A8905CE9F33ED1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>5A3750120EFC5FE7B1FF72E6AE18A998</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0DB5BD81DCAEB161F8916282ABFD3340</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
+				<string>9A1314F41D4AF302873CCAE4DF95096E</string>
+				<string>4D7A0A0B35C6A6AD7E9E0865060EEF5F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0E62CB0F51CFEF3EF98705FE6ED1BAA1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>B7098005E3463F71E30EE2ACC3981519</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0F0AD0445D068E37E1C8498A3BF6150D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SwiftyJSON-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>10E4A21EDDC41F94B30C17F38403E413</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>143405C094ED81774A475A1A942BA220</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E83328805FF2933A2C3CEF374AFC4887</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>14B7C4FE824293ABEEF592A7E71C4AFC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>154C747E02B1DCBD4885645B5878477F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>155E3FCDB75DFDBB152E101B4C202295</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>FayeSwift-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>15765D47A6F3AC9E1A1D641D8B2ADB93</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>17665D60312637FC3C2207AEFD337BAD</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>C05B711322CA076AB9A57512649A029E</string>
+				<string>6C0CE301D9536F43B5C8E08E16712E38</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>18B303F193AF762CF2DBE56F6B24B5CE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>18C6718FA411202146721CBD6539BA6A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Starscream-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1DCE2224000629085D044E4A5FDB2710</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1EC0280E5CCCCD96F81E63B562E157DD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>SwiftyJSON.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1F6C69005CE5773E87D416DED050CEA8</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>9E350CCD50346BBEAD007279DA919999</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Development Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1FACCE2E2A3269AA6618DC62E86A5B78</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8128B73B46CE4E130156947FEA792793</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/FayeSwift/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>FayeSwift</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1FFCDC3F1D5C704D66044A14414886F5</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>0A3C59C66401164839B33852471AF8AF</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>22E6B7DDC8DADDE451326034FD9E9C8E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>55B757366E7A17818E9E92058B503641</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>23759C35F6314285C1D642E0F13B2BF3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>10E4A21EDDC41F94B30C17F38403E413</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>252588F94F9C2291A3486B7067E69576</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>259498FBDA923366A8452198A57D1F08</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>9957AD0715343BA2E7013691E1E98F7F</string>
+			<key>buildPhases</key>
+			<array>
+				<string>F2F5FF28F679ADC8A92B329DFCDCE51F</string>
+				<string>1FFCDC3F1D5C704D66044A14414886F5</string>
+				<string>74D6B9A88E9B97B956BF27CEE1DADAC3</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>48D042132AC259FD381EA4D96E17C5B5</string>
+				<string>396DE1C1608FD26AC267D36844C6630E</string>
+				<string>743E721F930E22D28C87A28227016A4E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>productName</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>productReference</key>
+			<string>293CBC63DDF03144B25885047CA44A32</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>2692C5A026D6876DF0B8ED238232F2E6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>284F69195E7B74EADDB82148FD5DC647</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>2901A0000603C63521D4DED64D2B4586</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
+				<string>AA8A7B051C0D58209033A2F69D3D1CBA</string>
+				<string>E83328805FF2933A2C3CEF374AFC4887</string>
+				<string>487A65235BC761C63EA749D3504478B5</string>
+				<string>61F102DBDE488931620E8AA49183513B</string>
+				<string>B98F1A78B8406D8DE50340A8632588E9</string>
+				<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Sources</string>
+			<key>path</key>
+			<string>Sources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>293CBC63DDF03144B25885047CA44A32</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods_FayeSwift_Tests.framework</string>
+			<key>path</key>
+			<string>Pods_FayeSwift_Tests.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>2A14E4E75C0921B8190FF7805BDB1994</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftyJSON.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D4EF06156597B9C0C9800347C3343FC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
+				<string>FB45FFD90572718D82AB9092B750F0CA</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>2D9BE4E9101DCFEEF862D023F09073FA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>FayeSwift.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2FE9E957D59ADA0A662E4B8C1A7BD7E2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2FFB5CE6155C8F4095C8976A29498960</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>3EEFF32D5BCC2D64205AA37299BC9746</string>
+			<key>buildPhases</key>
+			<array>
+				<string>08C9E34BFE3CE6E33FB4863BF08E5C1B</string>
+				<string>0E62CB0F51CFEF3EF98705FE6ED1BAA1</string>
+				<string>0C93A0CF1060B47E24A8905CE9F33ED1</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>productName</key>
+			<string>Starscream</string>
+			<key>productReference</key>
+			<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>3434E7FC44AEA830A2C6B752B26BCE33</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SwiftyJSON/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>SwiftyJSON</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>344AD1F5AB3B588C01B21778050F2EAF</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>targetProxy</key>
+			<string>85FD64D2BAA74EAEF9935526FAFB1516</string>
+		</dict>
+		<key>37D9B4C012C932EED434E89C515FA960</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>38A444149F18F886FD0A1E23B45D6671</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>SSLSecurity.swift</string>
+			<key>path</key>
+			<string>Source/SSLSecurity.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>396DE1C1608FD26AC267D36844C6630E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>targetProxy</key>
+			<string>252588F94F9C2291A3486B7067E69576</string>
+		</dict>
+		<key>3E94F4BAAE418F28A0730CC56D7FACFF</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Starscream.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>3EEFF32D5BCC2D64205AA37299BC9746</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>B93968102E7FD3EAE8BED45C989328EF</string>
+				<string>82721887C459F67368E0CF06D91C7E57</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>40CE25E3C0BCCCA4C2AF868C127EE751</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>targetProxy</key>
+			<string>88B85D4B1942F047C1DC470C922B7703</string>
+		</dict>
+		<key>4471A15D81938B6C2CE6A161EC41FEED</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>47C7E36F0C36BF6A9B7F26250E6F35CA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Starscream-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>47C81FB96686C0BE581D0FC3090AFC0D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Starscream.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>487A65235BC761C63EA749D3504478B5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>NSError+Helper.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4885D84AE492246F7B92A35D5F4C2787</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>48BC61B70DBB2FA057A57FF358488F76</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>0813DA1F91E6465D940389B245DB41E4</string>
+				<string>9BE8F84C840D474BB60E62D4A8259C63</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>path</key>
+			<string>SwiftyJSON</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>48D042132AC259FD381EA4D96E17C5B5</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>target</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>targetProxy</key>
+			<string>B1C1530B6651528BC37303CE7401BF99</string>
+		</dict>
+		<key>49EE77FDD417AD6D8551E84B667F057D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C412C36AF79D03E0CB1D365F868D4F0B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>4AB2D41C9043F185BD735AC2476F72C6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4D7A0A0B35C6A6AD7E9E0865060EEF5F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>iOS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5171549988DEFF7760E6073814FFA524</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>548BDBC634056C39A523C64AB1870D93</key>
+		<dict>
+			<key>fileRef</key>
+			<string>87D64F48FA18233694918281C87E0266</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>55B757366E7A17818E9E92058B503641</key>
+		<dict>
+			<key>fileRef</key>
+			<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>57072CFE2F97B4E7645A18D9267BA425</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CFB3E404A66EE13E14582416D200A72C</string>
+				<string>ED0A84AABA966E6DE908E1D84ABB429E</string>
+				<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+				<string>18C6718FA411202146721CBD6539BA6A</string>
+				<string>47C7E36F0C36BF6A9B7F26250E6F35CA</string>
+				<string>D47E6B74B427A4904D75990D1C34E829</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Starscream</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5A3750120EFC5FE7B1FF72E6AE18A998</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D47E6B74B427A4904D75990D1C34E829</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>5CA1401B9C2AC9B84FD288DB6C3FC702</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>84EF024683CD3AA877927D77BAABE64F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>5D1E5C8AB017A941ACA43B001D23BCFA</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>targetProxy</key>
+			<string>E641FD10F82298D81E564BF16487B827</string>
+		</dict>
+		<key>5EA65666CE5344D192D5B67A85CAFA39</key>
+		<dict>
+			<key>fileRef</key>
+			<string>38A444149F18F886FD0A1E23B45D6671</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>61F102DBDE488931620E8AA49183513B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>StringExtensions.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>62E2EDCCDEE8B32C1115DA2D9C6361CC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>WebsocketTransport.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>64F09C054760D010B8E1B3BEB4671267</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods_FayeSwift_Example.framework</string>
+			<key>path</key>
+			<string>Pods_FayeSwift_Example.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>6B923F40E09322629BC57536AFBDAB00</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SwiftyJSON-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6C0CE301D9536F43B5C8E08E16712E38</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>2692C5A026D6876DF0B8ED238232F2E6</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Example</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>6CF3F2DD66CD874F21BF38ED13DD0295</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>remoteInfo</key>
+			<string>FayeSwift</string>
+		</dict>
+		<key>6DCD25231745CBB7A0DE8AE144F32C35</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SwiftyJSON-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6E1FB52B709CB783F4109CA61174C28B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>704BC00CA3D5CF10EF09C356B799A500</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9A1314F41D4AF302873CCAE4DF95096E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>743E721F930E22D28C87A28227016A4E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>targetProxy</key>
+			<string>A1B59F9DF18152F704FE8F577A69E455</string>
+		</dict>
+		<key>74D6B9A88E9B97B956BF27CEE1DADAC3</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>23759C35F6314285C1D642E0F13B2BF3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>786D4D05CB5776378133906FD2A40DE6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B98F1A78B8406D8DE50340A8632588E9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>7B7998CBFC4F64B40662D5BE2471EA16</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6B923F40E09322629BC57536AFBDAB00</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>7DB346D0F39D3F0E887471402A8071AB</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
+				<string>1F6C69005CE5773E87D416DED050CEA8</string>
+				<string>0DB5BD81DCAEB161F8916282ABFD3340</string>
+				<string>0C03422930E80D7BB92C5C859589F09F</string>
+				<string>9A590701475CDEC7488348815ADACCBC</string>
+				<string>000A61D7F0D0221F20F470656F297E70</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7F7A42B67F6F0E9E305772EB90285630</key>
+		<dict>
+			<key>fileRef</key>
+			<string>487A65235BC761C63EA749D3504478B5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>7FCD02EA8C46A7BE4F4C55DF12CEB124</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1FACCE2E2A3269AA6618DC62E86A5B78</string>
+				<string>FB4DED77D2E4800415AEB7F77228E2A1</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>8128B73B46CE4E130156947FEA792793</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>FayeSwift.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>82721887C459F67368E0CF06D91C7E57</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Starscream/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Starscream/Starscream.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>Starscream</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>84EF024683CD3AA877927D77BAABE64F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>85FD64D2BAA74EAEF9935526FAFB1516</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>86074C31635E6527FE9EB5D3D6DE479B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>87D64F48FA18233694918281C87E0266</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>WebSocket.swift</string>
+			<key>path</key>
+			<string>Source/WebSocket.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>88B85D4B1942F047C1DC470C922B7703</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2FFB5CE6155C8F4095C8976A29498960</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>9228804A5CB29EF1E2D8F805F0EEA281</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Starscream.framework</string>
+			<key>path</key>
+			<string>Starscream.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>957ADEE6257BB32E03F9E872F76D3479</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>968A19F12E6EEAFE1AF4E01F94F08D05</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9957AD0715343BA2E7013691E1E98F7F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>9D3BE8B79BE19FBE664EBECF0B50D300</string>
+				<string>BA99F75B86D32E8C1D12F5167359D6E2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>9A1314F41D4AF302873CCAE4DF95096E</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftyJSON.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9A590701475CDEC7488348815ADACCBC</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
+				<string>64F09C054760D010B8E1B3BEB4671267</string>
+				<string>293CBC63DDF03144B25885047CA44A32</string>
+				<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
+				<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9BE8F84C840D474BB60E62D4A8259C63</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>E6671F9532A947F40918CF9A0D44F70F</string>
+				<string>2A14E4E75C0921B8190FF7805BDB1994</string>
+				<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+				<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
+				<string>0F0AD0445D068E37E1C8498A3BF6150D</string>
+				<string>6B923F40E09322629BC57536AFBDAB00</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/SwiftyJSON</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9D3BE8B79BE19FBE664EBECF0B50D300</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Tests</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>9E350CCD50346BBEAD007279DA919999</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>2901A0000603C63521D4DED64D2B4586</string>
+				<string>DEC84C118AC1DA713A832BFDF21F45E2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>path</key>
+			<string>../..</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9EADFEED37C12003F2FE470649EF5A49</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>E7DD6469E226114253998E809F39BCD1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A16806250A7E7DD443C4EDB15A117D0E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>7B7998CBFC4F64B40662D5BE2471EA16</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A1B59F9DF18152F704FE8F577A69E455</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>A579A389F40ED521DC90FA82DA684595</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FF972453FA7F311A42163A996F627326</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>A96B9484D73AF99585C0F4500550DE5A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>155E3FCDB75DFDBB152E101B4C202295</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AA8A7B051C0D58209033A2F69D3D1CBA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeClientDelegate.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AEC58E9B2FE610C5D55CBB2FA4D34F2A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>6E1FB52B709CB783F4109CA61174C28B</string>
+				<string>37D9B4C012C932EED434E89C515FA960</string>
+				<string>4471A15D81938B6C2CE6A161EC41FEED</string>
+				<string>B29C7FFE8D08A56E77C644C03000FC94</string>
+				<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
+				<string>14B7C4FE824293ABEEF592A7E71C4AFC</string>
+				<string>4885D84AE492246F7B92A35D5F4C2787</string>
+				<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
+				<string>B661AAF1FC01F5B9EB53567F4990C215</string>
+				<string>2692C5A026D6876DF0B8ED238232F2E6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-FayeSwift_Example</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B0F7AB6108413A1758B2F2D999AED350</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>17665D60312637FC3C2207AEFD337BAD</string>
+			<key>buildPhases</key>
+			<array>
+				<string>5CA1401B9C2AC9B84FD288DB6C3FC702</string>
+				<string>E307332C7150A001B3765B245D2D6839</string>
+				<string>22E6B7DDC8DADDE451326034FD9E9C8E</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>050F3648989E5C1D6979F7A0EDAA352A</string>
+				<string>344AD1F5AB3B588C01B21778050F2EAF</string>
+				<string>5D1E5C8AB017A941ACA43B001D23BCFA</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>productName</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>productReference</key>
+			<string>64F09C054760D010B8E1B3BEB4671267</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>B1C1530B6651528BC37303CE7401BF99</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+			<key>remoteInfo</key>
+			<string>FayeSwift</string>
+		</dict>
+		<key>B267AB921ABBC8B1A9D9D568D0D05615</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>SwiftyJSON.framework</string>
+			<key>path</key>
+			<string>SwiftyJSON.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>B29C7FFE8D08A56E77C644C03000FC94</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B60722EF6A0F9DCD2D7C6D03F8B362CD</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>38A444149F18F886FD0A1E23B45D6671</string>
+				<string>87D64F48FA18233694918281C87E0266</string>
+				<string>57072CFE2F97B4E7645A18D9267BA425</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>path</key>
+			<string>Starscream</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B661AAF1FC01F5B9EB53567F4990C215</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B67F6FB5E88D459FDF1CC4FD93CB5D6B</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>FayeSwift.framework</string>
+			<key>path</key>
+			<string>FayeSwift.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>B7098005E3463F71E30EE2ACC3981519</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B8D637FB9D47D77BBA1D7A37CE57E05F</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>B93968102E7FD3EAE8BED45C989328EF</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Starscream/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Starscream/Starscream.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>Starscream</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>B98F1A78B8406D8DE50340A8632588E9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>Transport.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B9BD316B84610E564DEC11C4F736BD36</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>name</key>
+			<string>Podfile</string>
+			<key>path</key>
+			<string>../Podfile</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.ruby</string>
+		</dict>
+		<key>BA7367A9809BA19B15229BD6A97BF748</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0813DA1F91E6465D940389B245DB41E4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>BA99F75B86D32E8C1D12F5167359D6E2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>4AB2D41C9043F185BD735AC2476F72C6</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Tests</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>C05B711322CA076AB9A57512649A029E</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>B661AAF1FC01F5B9EB53567F4990C215</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Example</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>C412C36AF79D03E0CB1D365F868D4F0B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeClient.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C56D3FE3F52A8D747E34473EF1315CF7</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>7FCD02EA8C46A7BE4F4C55DF12CEB124</string>
+			<key>buildPhases</key>
+			<array>
+				<string>EC58A33380EA9B37BB944B04C1F3AE53</string>
+				<string>0AC47F7781401C3893E4D44D51617586</string>
+				<string>F912B38D7469867C424F80F4C8770DEB</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>40CE25E3C0BCCCA4C2AF868C127EE751</string>
+				<string>F127B67BA9F6A72ECEF5BAD63C4F3BED</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>productName</key>
+			<string>FayeSwift</string>
+			<key>productReference</key>
+			<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>CFB3E404A66EE13E14582416D200A72C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D26B5E2282A330BE919FE4EFDFB738B3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D41D8CD98F00B204E9800998ECF8427E</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0700</string>
+				<key>LastUpgradeCheck</key>
+				<string>0700</string>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>7DB346D0F39D3F0E887471402A8071AB</string>
+			<key>productRefGroup</key>
+			<string>9A590701475CDEC7488348815ADACCBC</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>C56D3FE3F52A8D747E34473EF1315CF7</string>
+				<string>B0F7AB6108413A1758B2F2D999AED350</string>
+				<string>259498FBDA923366A8452198A57D1F08</string>
+				<string>2FFB5CE6155C8F4095C8976A29498960</string>
+				<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			</array>
+		</dict>
+		<key>D47E6B74B427A4904D75990D1C34E829</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Starscream-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D4E1B392E0B7E62D774C23D5F31E2CEC</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>F9256BA24236127F4EA11F8A1F99C6DF</string>
+				<string>BA7367A9809BA19B15229BD6A97BF748</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>D5A61BB662B60E80642A24E32724275E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>18C6718FA411202146721CBD6539BA6A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>D7AD1CA221F811429F2397EA408725EE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1DCE2224000629085D044E4A5FDB2710</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DEC84C118AC1DA713A832BFDF21F45E2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>2D9BE4E9101DCFEEF862D023F09073FA</string>
+				<string>8128B73B46CE4E130156947FEA792793</string>
+				<string>FF972453FA7F311A42163A996F627326</string>
+				<string>EB7D54C397F58433A25DA043B2ED90B3</string>
+				<string>155E3FCDB75DFDBB152E101B4C202295</string>
+				<string>86074C31635E6527FE9EB5D3D6DE479B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>Example/Pods/Target Support Files/FayeSwift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E307332C7150A001B3765B245D2D6839</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>968A19F12E6EEAFE1AF4E01F94F08D05</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>E4E07C18061452192A8755C57422BE93</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E52013BD1A2AEE87A4182D2DEFAD6C4C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>61F102DBDE488931620E8AA49183513B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>E641FD10F82298D81E564BF16487B827</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>E6671F9532A947F40918CF9A0D44F70F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E7DD6469E226114253998E809F39BCD1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>E83328805FF2933A2C3CEF374AFC4887</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeSubscriptionModel.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EB7D54C397F58433A25DA043B2ED90B3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>FayeSwift-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EC58A33380EA9B37BB944B04C1F3AE53</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>49EE77FDD417AD6D8551E84B667F057D</string>
+				<string>284F69195E7B74EADDB82148FD5DC647</string>
+				<string>143405C094ED81774A475A1A942BA220</string>
+				<string>A579A389F40ED521DC90FA82DA684595</string>
+				<string>7F7A42B67F6F0E9E305772EB90285630</string>
+				<string>E52013BD1A2AEE87A4182D2DEFAD6C4C</string>
+				<string>786D4D05CB5776378133906FD2A40DE6</string>
+				<string>F2114CECEB4EB16988736CE300F5ADDC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>ED0A84AABA966E6DE908E1D84ABB429E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Starscream.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F01BE1D9270805A4A53EB2B5924A139E</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>0AEC95D7E93685709B9C6A5B00BDDEB7</string>
+			<key>buildPhases</key>
+			<array>
+				<string>D4E1B392E0B7E62D774C23D5F31E2CEC</string>
+				<string>9EADFEED37C12003F2FE470649EF5A49</string>
+				<string>A16806250A7E7DD443C4EDB15A117D0E</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>productName</key>
+			<string>SwiftyJSON</string>
+			<key>productReference</key>
+			<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>F127B67BA9F6A72ECEF5BAD63C4F3BED</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>F01BE1D9270805A4A53EB2B5924A139E</string>
+			<key>targetProxy</key>
+			<string>5171549988DEFF7760E6073814FFA524</string>
+		</dict>
+		<key>F2114CECEB4EB16988736CE300F5ADDC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>62E2EDCCDEE8B32C1115DA2D9C6361CC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>F2F5FF28F679ADC8A92B329DFCDCE51F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>D7AD1CA221F811429F2397EA408725EE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F3FCAA0DF279AAE5F2E8878F0749DD44</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F912B38D7469867C424F80F4C8770DEB</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>A96B9484D73AF99585C0F4500550DE5A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F9256BA24236127F4EA11F8A1F99C6DF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>FB45FFD90572718D82AB9092B750F0CA</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>RELEASE=1</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>FB4DED77D2E4800415AEB7F77228E2A1</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8128B73B46CE4E130156947FEA792793</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/FayeSwift/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>FayeSwift</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>FF972453FA7F311A42163A996F627326</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>FayeSwift-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>D41D8CD98F00B204E9800998ECF8427E</string>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,1067 +1,2691 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		20A933EEF1CA9FD68B87FFD3961DFD19 /* Starscream-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		257FE96D3779E79C92E2178695503795 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		3E99BDBD769E005054DAD2B80FE8C90F /* FayeSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AE2DB2475AFBEB3E54A28F1728DE4FF /* FayeSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		60F107B01844DFC970665ADCCD342745 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */; };
-		6C58DDFB5310A6DB5074D67F0C72DB12 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */; };
-		85608F7B54AA7F914F5D533F623C043A /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D64F48FA18233694918281C87E0266 /* WebSocket.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8A3D5E5BD10FCED12B02633324D86B4E /* SwiftyJSON-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		9EBD2DD2180F2F2E4BDFCA61C5B2ABD5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */; };
-		B4F678AEE6EB79E2974E3722F62E62A6 /* Starscream-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */; };
-		C120FD7E7730F7B2CBE9AE82C32A2025 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C924D77076DD0B85DE38D93F6D09361B /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */; };
-		CF3C815427C32948D42D7D7748DC81A1 /* SwiftyJSON-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */; };
-		D5142ACB1C74931E00622C44 /* NSError+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5142ACA1C74931E00622C44 /* NSError+Helper.swift */; };
-		D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */; };
-		E17F2E2D9A8FE236916AA8F3B5F02A8F /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */; };
-		EA183AF116D9067CDF9A5EF14FD8FBAA /* FayeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68B46D54A88A9E061CC95ED5879C5CB /* FayeClient.swift */; };
-		FCAA884AE40C15F5271F02911FAB43F1 /* FayeSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D05D2436CA4D4CF0BC966121EF07ACF /* FayeSwift-dummy.m */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F1772C84BE57510CE8756C21202F5091;
-			remoteInfo = Starscream;
-		};
-		40393CA01DFFFC057A5F6BA5AD40ECD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D8DDA82807E484CC8E9331F4752FC7E7;
-			remoteInfo = SwiftyJSON;
-		};
-		6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F171C03A9A34D854F6CFB14AE8549E37;
-			remoteInfo = FayeSwift;
-		};
-		85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F1772C84BE57510CE8756C21202F5091;
-			remoteInfo = Starscream;
-		};
-		A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D8DDA82807E484CC8E9331F4752FC7E7;
-			remoteInfo = SwiftyJSON;
-		};
-		B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F171C03A9A34D854F6CFB14AE8549E37;
-			remoteInfo = FayeSwift;
-		};
-		B9F6B1C70B37F9DD73C1536A154397D2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F1772C84BE57510CE8756C21202F5091;
-			remoteInfo = Starscream;
-		};
-		E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D8DDA82807E484CC8E9331F4752FC7E7;
-			remoteInfo = SwiftyJSON;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Example-umbrella.h"; sourceTree = "<group>"; };
-		0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
-		0AE2DB2475AFBEB3E54A28F1728DE4FF /* FayeSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-umbrella.h"; sourceTree = "<group>"; };
-		0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
-		10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FayeSwift_Tests-umbrella.h"; sourceTree = "<group>"; };
-		14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-frameworks.sh"; sourceTree = "<group>"; };
-		154C747E02B1DCBD4885645B5878477F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Starscream-dummy.m"; sourceTree = "<group>"; };
-		1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Tests-dummy.m"; sourceTree = "<group>"; };
-		1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
-		2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
-		293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
-		2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-FayeSwift_Example-dummy.m"; sourceTree = "<group>"; };
-		37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Example.modulemap"; sourceTree = "<group>"; };
-		38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Source/SSLSecurity.swift; sourceTree = "<group>"; };
-		3D05D2436CA4D4CF0BC966121EF07ACF /* FayeSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FayeSwift-dummy.m"; sourceTree = "<group>"; };
-		3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FayeSwift_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		474A439AD1BDC171F904238148218864 /* FayeSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FayeSwift.xcconfig; sourceTree = "<group>"; };
-		47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-prefix.pch"; sourceTree = "<group>"; };
-		47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.xcconfig; sourceTree = "<group>"; };
-		4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Example-resources.sh"; sourceTree = "<group>"; };
-		4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		53067CE266C021A51418758A281A52DF /* FayeSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FayeSwift-prefix.pch"; sourceTree = "<group>"; };
-		64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FayeSwift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
-		6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftyJSON-dummy.m"; sourceTree = "<group>"; };
-		6E1FB52B709CB783F4109CA61174C28B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		87D64F48FA18233694918281C87E0266 /* WebSocket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Source/WebSocket.swift; sourceTree = "<group>"; };
-		8F5AE739E59BF3501F99DA5B711F4217 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FayeSwift_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FayeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-resources.sh"; sourceTree = "<group>"; };
-		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		CFB3E404A66EE13E14582416D200A72C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FayeSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Starscream-umbrella.h"; sourceTree = "<group>"; };
-		D5142ACA1C74931E00622C44 /* NSError+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+Helper.swift"; sourceTree = "<group>"; };
-		D97CF598701325B6B933A5EE31D58366 /* FayeSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = FayeSwift.modulemap; sourceTree = "<group>"; };
-		E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FayeSwift_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		E6671F9532A947F40918CF9A0D44F70F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E68B46D54A88A9E061CC95ED5879C5CB /* FayeClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FayeClient.swift; sourceTree = "<group>"; };
-		ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Starscream.modulemap; sourceTree = "<group>"; };
-		F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-FayeSwift_Tests.modulemap"; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0A3C59C66401164839B33852471AF8AF /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		392A3C26F55FA4A2F45BCA8DBF3896AE /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6C58DDFB5310A6DB5074D67F0C72DB12 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		436584CA974FA7C7474E9ECF3738C65E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				257FE96D3779E79C92E2178695503795 /* Foundation.framework in Frameworks */,
-				C924D77076DD0B85DE38D93F6D09361B /* Starscream.framework in Frameworks */,
-				60F107B01844DFC970665ADCCD342745 /* SwiftyJSON.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9DD087EF6E34D5BC10AE35F8E9591BB0 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9EBD2DD2180F2F2E4BDFCA61C5B2ABD5 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E307332C7150A001B3765B245D2D6839 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				968A19F12E6EEAFE1AF4E01F94F08D05 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */,
-				0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		0A3C1A1DE210D08A1510BD9669BDF551 /* Pods-FayeSwift_Tests */ = {
-			isa = PBXGroup;
-			children = (
-				154C747E02B1DCBD4885645B5878477F /* Info.plist */,
-				F3FCAA0DF279AAE5F2E8878F0749DD44 /* Pods-FayeSwift_Tests.modulemap */,
-				2D4EF06156597B9C0C9800347C3343FC /* Pods-FayeSwift_Tests-acknowledgements.markdown */,
-				15765D47A6F3AC9E1A1D641D8B2ADB93 /* Pods-FayeSwift_Tests-acknowledgements.plist */,
-				1DCE2224000629085D044E4A5FDB2710 /* Pods-FayeSwift_Tests-dummy.m */,
-				E4E07C18061452192A8755C57422BE93 /* Pods-FayeSwift_Tests-frameworks.sh */,
-				B9BD316B84610E564DEC11C4F736BD36 /* Pods-FayeSwift_Tests-resources.sh */,
-				10E4A21EDDC41F94B30C17F38403E413 /* Pods-FayeSwift_Tests-umbrella.h */,
-				D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */,
-				4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */,
-			);
-			name = "Pods-FayeSwift_Tests";
-			path = "Target Support Files/Pods-FayeSwift_Tests";
-			sourceTree = "<group>";
-		};
-		0C03422930E80D7BB92C5C859589F09F /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */,
-				48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				3E94F4BAAE418F28A0730CC56D7FACFF /* Starscream.framework */,
-				9A1314F41D4AF302873CCAE4DF95096E /* SwiftyJSON.framework */,
-				4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		1F283DB717AA6920F142FCF3523AA44B /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				D97CF598701325B6B933A5EE31D58366 /* FayeSwift.modulemap */,
-				474A439AD1BDC171F904238148218864 /* FayeSwift.xcconfig */,
-				3D05D2436CA4D4CF0BC966121EF07ACF /* FayeSwift-dummy.m */,
-				53067CE266C021A51418758A281A52DF /* FayeSwift-prefix.pch */,
-				0AE2DB2475AFBEB3E54A28F1728DE4FF /* FayeSwift-umbrella.h */,
-				8F5AE739E59BF3501F99DA5B711F4217 /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/FayeSwift";
-			sourceTree = "<group>";
-		};
-		1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				99C3126EEC635907C1BB96DA2B94B4F3 /* FayeSwift */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		48BC61B70DBB2FA057A57FF358488F76 /* SwiftyJSON */ = {
-			isa = PBXGroup;
-			children = (
-				0813DA1F91E6465D940389B245DB41E4 /* SwiftyJSON.swift */,
-				9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */,
-			);
-			path = SwiftyJSON;
-			sourceTree = "<group>";
-		};
-		4D7A0A0B35C6A6AD7E9E0865060EEF5F /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				B8D637FB9D47D77BBA1D7A37CE57E05F /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		57072CFE2F97B4E7645A18D9267BA425 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CFB3E404A66EE13E14582416D200A72C /* Info.plist */,
-				ED0A84AABA966E6DE908E1D84ABB429E /* Starscream.modulemap */,
-				47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */,
-				18C6718FA411202146721CBD6539BA6A /* Starscream-dummy.m */,
-				47C7E36F0C36BF6A9B7F26250E6F35CA /* Starscream-prefix.pch */,
-				D47E6B74B427A4904D75990D1C34E829 /* Starscream-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Starscream";
-			sourceTree = "<group>";
-		};
-		7DB346D0F39D3F0E887471402A8071AB = {
-			isa = PBXGroup;
-			children = (
-				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
-				1F6C69005CE5773E87D416DED050CEA8 /* Development Pods */,
-				0DB5BD81DCAEB161F8916282ABFD3340 /* Frameworks */,
-				0C03422930E80D7BB92C5C859589F09F /* Pods */,
-				9A590701475CDEC7488348815ADACCBC /* Products */,
-				000A61D7F0D0221F20F470656F297E70 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		99C3126EEC635907C1BB96DA2B94B4F3 /* FayeSwift */ = {
-			isa = PBXGroup;
-			children = (
-				D791F2066D5A1C094F2D76F436C24AAF /* Sources */,
-				1F283DB717AA6920F142FCF3523AA44B /* Support Files */,
-			);
-			name = FayeSwift;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		9A590701475CDEC7488348815ADACCBC /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */,
-				64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */,
-				293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */,
-				9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */,
-				B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		9BE8F84C840D474BB60E62D4A8259C63 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E6671F9532A947F40918CF9A0D44F70F /* Info.plist */,
-				2A14E4E75C0921B8190FF7805BDB1994 /* SwiftyJSON.modulemap */,
-				1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */,
-				6DCD25231745CBB7A0DE8AE144F32C35 /* SwiftyJSON-dummy.m */,
-				0F0AD0445D068E37E1C8498A3BF6150D /* SwiftyJSON-prefix.pch */,
-				6B923F40E09322629BC57536AFBDAB00 /* SwiftyJSON-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftyJSON";
-			sourceTree = "<group>";
-		};
-		AEC58E9B2FE610C5D55CBB2FA4D34F2A /* Pods-FayeSwift_Example */ = {
-			isa = PBXGroup;
-			children = (
-				6E1FB52B709CB783F4109CA61174C28B /* Info.plist */,
-				37D9B4C012C932EED434E89C515FA960 /* Pods-FayeSwift_Example.modulemap */,
-				4471A15D81938B6C2CE6A161EC41FEED /* Pods-FayeSwift_Example-acknowledgements.markdown */,
-				B29C7FFE8D08A56E77C644C03000FC94 /* Pods-FayeSwift_Example-acknowledgements.plist */,
-				2FE9E957D59ADA0A662E4B8C1A7BD7E2 /* Pods-FayeSwift_Example-dummy.m */,
-				14B7C4FE824293ABEEF592A7E71C4AFC /* Pods-FayeSwift_Example-frameworks.sh */,
-				4885D84AE492246F7B92A35D5F4C2787 /* Pods-FayeSwift_Example-resources.sh */,
-				06B16C30B7CF62C246F4DD2B6BA325D2 /* Pods-FayeSwift_Example-umbrella.h */,
-				B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */,
-				2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */,
-			);
-			name = "Pods-FayeSwift_Example";
-			path = "Target Support Files/Pods-FayeSwift_Example";
-			sourceTree = "<group>";
-		};
-		B60722EF6A0F9DCD2D7C6D03F8B362CD /* Starscream */ = {
-			isa = PBXGroup;
-			children = (
-				38A444149F18F886FD0A1E23B45D6671 /* SSLSecurity.swift */,
-				87D64F48FA18233694918281C87E0266 /* WebSocket.swift */,
-				57072CFE2F97B4E7645A18D9267BA425 /* Support Files */,
-			);
-			path = Starscream;
-			sourceTree = "<group>";
-		};
-		D791F2066D5A1C094F2D76F436C24AAF /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				E68B46D54A88A9E061CC95ED5879C5CB /* FayeClient.swift */,
-				D5142ACA1C74931E00622C44 /* NSError+Helper.swift */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		1A0893C7CFF87E88B5143251879DB476 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3E99BDBD769E005054DAD2B80FE8C90F /* FayeSwift-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				55B757366E7A17818E9E92058B503641 /* Pods-FayeSwift_Example-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		503E4B8E7E2A185BBF2E4C6207658976 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8A3D5E5BD10FCED12B02633324D86B4E /* SwiftyJSON-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				23759C35F6314285C1D642E0F13B2BF3 /* Pods-FayeSwift_Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FF3ED48966FF22221073A5B823ADF014 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				20A933EEF1CA9FD68B87FFD3961DFD19 /* Starscream-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */;
-			buildPhases = (
-				F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */,
-				1FFCDC3F1D5C704D66044A14414886F5 /* Frameworks */,
-				74D6B9A88E9B97B956BF27CEE1DADAC3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */,
-				396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */,
-				743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */,
-			);
-			name = "Pods-FayeSwift_Tests";
-			productName = "Pods-FayeSwift_Tests";
-			productReference = 293CBC63DDF03144B25885047CA44A32 /* Pods_FayeSwift_Tests.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */;
-			buildPhases = (
-				5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */,
-				E307332C7150A001B3765B245D2D6839 /* Frameworks */,
-				22E6B7DDC8DADDE451326034FD9E9C8E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */,
-				344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */,
-				5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */,
-			);
-			name = "Pods-FayeSwift_Example";
-			productName = "Pods-FayeSwift_Example";
-			productReference = 64F09C054760D010B8E1B3BEB4671267 /* Pods_FayeSwift_Example.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		D8DDA82807E484CC8E9331F4752FC7E7 /* SwiftyJSON */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CBF399B7ED8DDB53F99BE9C2AD40DA5B /* Build configuration list for PBXNativeTarget "SwiftyJSON" */;
-			buildPhases = (
-				75D06416AD2E2CA92DAA7D485C037126 /* Sources */,
-				9DD087EF6E34D5BC10AE35F8E9591BB0 /* Frameworks */,
-				503E4B8E7E2A185BBF2E4C6207658976 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftyJSON;
-			productName = SwiftyJSON;
-			productReference = B267AB921ABBC8B1A9D9D568D0D05615 /* SwiftyJSON.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		F171C03A9A34D854F6CFB14AE8549E37 /* FayeSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 6B10560913A161F0E419D2B8B7701C30 /* Build configuration list for PBXNativeTarget "FayeSwift" */;
-			buildPhases = (
-				7AA6DE7028155611388EA1714CF0167A /* Sources */,
-				436584CA974FA7C7474E9ECF3738C65E /* Frameworks */,
-				1A0893C7CFF87E88B5143251879DB476 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				2E0D1CAC18DD2174842E8FBC85A04A9A /* PBXTargetDependency */,
-				F3D47D1F1E914682BDB0717A5C52C5EF /* PBXTargetDependency */,
-			);
-			name = FayeSwift;
-			productName = FayeSwift;
-			productReference = B67F6FB5E88D459FDF1CC4FD93CB5D6B /* FayeSwift.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		F1772C84BE57510CE8756C21202F5091 /* Starscream */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 2E153441E811CC57A525BA9C9A61A1F2 /* Build configuration list for PBXNativeTarget "Starscream" */;
-			buildPhases = (
-				64B48BC0D0F0EBB4226439F576925386 /* Sources */,
-				392A3C26F55FA4A2F45BCA8DBF3896AE /* Frameworks */,
-				FF3ED48966FF22221073A5B823ADF014 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Starscream;
-			productName = Starscream;
-			productReference = 9228804A5CB29EF1E2D8F805F0EEA281 /* Starscream.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
-			};
-			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 9A590701475CDEC7488348815ADACCBC /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				F171C03A9A34D854F6CFB14AE8549E37 /* FayeSwift */,
-				B0F7AB6108413A1758B2F2D999AED350 /* Pods-FayeSwift_Example */,
-				259498FBDA923366A8452198A57D1F08 /* Pods-FayeSwift_Tests */,
-				F1772C84BE57510CE8756C21202F5091 /* Starscream */,
-				D8DDA82807E484CC8E9331F4752FC7E7 /* SwiftyJSON */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		5CA1401B9C2AC9B84FD288DB6C3FC702 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				84EF024683CD3AA877927D77BAABE64F /* Pods-FayeSwift_Example-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		64B48BC0D0F0EBB4226439F576925386 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C120FD7E7730F7B2CBE9AE82C32A2025 /* SSLSecurity.swift in Sources */,
-				B4F678AEE6EB79E2974E3722F62E62A6 /* Starscream-dummy.m in Sources */,
-				85608F7B54AA7F914F5D533F623C043A /* WebSocket.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		75D06416AD2E2CA92DAA7D485C037126 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CF3C815427C32948D42D7D7748DC81A1 /* SwiftyJSON-dummy.m in Sources */,
-				E17F2E2D9A8FE236916AA8F3B5F02A8F /* SwiftyJSON.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7AA6DE7028155611388EA1714CF0167A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D5142ACB1C74931E00622C44 /* NSError+Helper.swift in Sources */,
-				EA183AF116D9067CDF9A5EF14FD8FBAA /* FayeClient.swift in Sources */,
-				FCAA884AE40C15F5271F02911FAB43F1 /* FayeSwift-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F2F5FF28F679ADC8A92B329DFCDCE51F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D7AD1CA221F811429F2397EA408725EE /* Pods-FayeSwift_Tests-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		050F3648989E5C1D6979F7A0EDAA352A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FayeSwift;
-			target = F171C03A9A34D854F6CFB14AE8549E37 /* FayeSwift */;
-			targetProxy = 6CF3F2DD66CD874F21BF38ED13DD0295 /* PBXContainerItemProxy */;
-		};
-		2E0D1CAC18DD2174842E8FBC85A04A9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = F1772C84BE57510CE8756C21202F5091 /* Starscream */;
-			targetProxy = B9F6B1C70B37F9DD73C1536A154397D2 /* PBXContainerItemProxy */;
-		};
-		344AD1F5AB3B588C01B21778050F2EAF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = F1772C84BE57510CE8756C21202F5091 /* Starscream */;
-			targetProxy = 85FD64D2BAA74EAEF9935526FAFB1516 /* PBXContainerItemProxy */;
-		};
-		396DE1C1608FD26AC267D36844C6630E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Starscream;
-			target = F1772C84BE57510CE8756C21202F5091 /* Starscream */;
-			targetProxy = 252588F94F9C2291A3486B7067E69576 /* PBXContainerItemProxy */;
-		};
-		48D042132AC259FD381EA4D96E17C5B5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FayeSwift;
-			target = F171C03A9A34D854F6CFB14AE8549E37 /* FayeSwift */;
-			targetProxy = B1C1530B6651528BC37303CE7401BF99 /* PBXContainerItemProxy */;
-		};
-		5D1E5C8AB017A941ACA43B001D23BCFA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = D8DDA82807E484CC8E9331F4752FC7E7 /* SwiftyJSON */;
-			targetProxy = E641FD10F82298D81E564BF16487B827 /* PBXContainerItemProxy */;
-		};
-		743E721F930E22D28C87A28227016A4E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = D8DDA82807E484CC8E9331F4752FC7E7 /* SwiftyJSON */;
-			targetProxy = A1B59F9DF18152F704FE8F577A69E455 /* PBXContainerItemProxy */;
-		};
-		F3D47D1F1E914682BDB0717A5C52C5EF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftyJSON;
-			target = D8DDA82807E484CC8E9331F4752FC7E7 /* SwiftyJSON */;
-			targetProxy = 40393CA01DFFFC057A5F6BA5AD40ECD5 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		10DE1947DAC0ED28F6C0A9F9BD75D546 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		15E2E7B249DDAF953656EC8D84F2A96B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2692C5A026D6876DF0B8ED238232F2E6 /* Pods-FayeSwift_Example.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		21918E6F0F5C88ABFA5B530851F1F5AF /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Starscream;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		27FFB7D3A789A60433117C7993DD5497 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 474A439AD1BDC171F904238148218864 /* FayeSwift.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = FayeSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		3BC84B6209EB0A997B3336E303A0FA62 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47C81FB96686C0BE581D0FC3090AFC0D /* Starscream.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Starscream/Starscream-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Starscream/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Starscream/Starscream.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Starscream;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		4904B7C8530726A1D4CC3AC951A95783 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 474A439AD1BDC171F904238148218864 /* FayeSwift.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/FayeSwift/FayeSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/FayeSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FayeSwift/FayeSwift.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = FayeSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		494FCB3FB898216E2F8280DD540668DD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D26B5E2282A330BE919FE4EFDFB738B3 /* Pods-FayeSwift_Tests.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		552D02D5BA751AC2E8790D2811D496CA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				ONLY_ACTIVE_ARCH = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Debug;
-		};
-		6EC63CCFD207A269E25ED4496EF53D56 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B661AAF1FC01F5B9EB53567F4990C215 /* Pods-FayeSwift_Example.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		7F99190CA4AAC23FAFC5A184E84941A9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		B9F4FE1D3DD56249D07C1043FF88D84B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EC0280E5CCCCD96F81E63B562E157DD /* SwiftyJSON.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SwiftyJSON/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SwiftyJSON/SwiftyJSON.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = SwiftyJSON;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		DCE1C70E61D22F711CA5E4FEF4F184EB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4AB2D41C9043F185BD735AC2476F72C6 /* Pods-FayeSwift_Tests.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-FayeSwift_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_FayeSwift_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		17665D60312637FC3C2207AEFD337BAD /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Example" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				6EC63CCFD207A269E25ED4496EF53D56 /* Debug */,
-				15E2E7B249DDAF953656EC8D84F2A96B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				552D02D5BA751AC2E8790D2811D496CA /* Debug */,
-				10DE1947DAC0ED28F6C0A9F9BD75D546 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		2E153441E811CC57A525BA9C9A61A1F2 /* Build configuration list for PBXNativeTarget "Starscream" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				21918E6F0F5C88ABFA5B530851F1F5AF /* Debug */,
-				3BC84B6209EB0A997B3336E303A0FA62 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		6B10560913A161F0E419D2B8B7701C30 /* Build configuration list for PBXNativeTarget "FayeSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27FFB7D3A789A60433117C7993DD5497 /* Debug */,
-				4904B7C8530726A1D4CC3AC951A95783 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		9957AD0715343BA2E7013691E1E98F7F /* Build configuration list for PBXNativeTarget "Pods-FayeSwift_Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				494FCB3FB898216E2F8280DD540668DD /* Debug */,
-				DCE1C70E61D22F711CA5E4FEF4F184EB /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CBF399B7ED8DDB53F99BE9C2AD40DA5B /* Build configuration list for PBXNativeTarget "SwiftyJSON" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7F99190CA4AAC23FAFC5A184E84941A9 /* Debug */,
-				B9F4FE1D3DD56249D07C1043FF88D84B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>000A61D7F0D0221F20F470656F297E70</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>AEC58E9B2FE610C5D55CBB2FA4D34F2A</string>
+				<string>0A3C1A1DE210D08A1510BD9669BDF551</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Targets Support Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>002C971AF7CA74392977401F3B5915E3</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>050F3648989E5C1D6979F7A0EDAA352A</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>target</key>
+			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
+			<key>targetProxy</key>
+			<string>6CF3F2DD66CD874F21BF38ED13DD0295</string>
+		</dict>
+		<key>06B16C30B7CF62C246F4DD2B6BA325D2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0813DA1F91E6465D940389B245DB41E4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>SwiftyJSON.swift</string>
+			<key>path</key>
+			<string>Source/SwiftyJSON.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0A3C1A1DE210D08A1510BD9669BDF551</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>154C747E02B1DCBD4885645B5878477F</string>
+				<string>F3FCAA0DF279AAE5F2E8878F0749DD44</string>
+				<string>2D4EF06156597B9C0C9800347C3343FC</string>
+				<string>15765D47A6F3AC9E1A1D641D8B2ADB93</string>
+				<string>1DCE2224000629085D044E4A5FDB2710</string>
+				<string>E4E07C18061452192A8755C57422BE93</string>
+				<string>B9BD316B84610E564DEC11C4F736BD36</string>
+				<string>10E4A21EDDC41F94B30C17F38403E413</string>
+				<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
+				<string>4AB2D41C9043F185BD735AC2476F72C6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-FayeSwift_Tests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0A3C59C66401164839B33852471AF8AF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>0C03422930E80D7BB92C5C859589F09F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B60722EF6A0F9DCD2D7C6D03F8B362CD</string>
+				<string>48BC61B70DBB2FA057A57FF358488F76</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0D76A5AF0D4781BFAC4D92B66E3A30B4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9A1314F41D4AF302873CCAE4DF95096E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>0DB5BD81DCAEB161F8916282ABFD3340</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
+				<string>9A1314F41D4AF302873CCAE4DF95096E</string>
+				<string>4D7A0A0B35C6A6AD7E9E0865060EEF5F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0F0AD0445D068E37E1C8498A3BF6150D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SwiftyJSON-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0FFB2621535432DEA9289D0F9EEEE26C</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>6A4FCAF5C9B5FE17B150653EFC153B3C</string>
+			<key>buildPhases</key>
+			<array>
+				<string>6F6B01E4869FC29404539D1F7EA47967</string>
+				<string>C3E208C52EE6C8C0689C1B94807309CD</string>
+				<string>9361BD7539E0A621237603846E00D81E</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>productName</key>
+			<string>Starscream</string>
+			<key>productReference</key>
+			<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>10E4A21EDDC41F94B30C17F38403E413</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>112044DE1A7A5E8036447F0CC4CA58CB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>14B7C4FE824293ABEEF592A7E71C4AFC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>154C747E02B1DCBD4885645B5878477F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>15765D47A6F3AC9E1A1D641D8B2ADB93</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>172D87FC5B15E2E05E643DD1188F953D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E09B4B87B5F08505B3484854BDF5F693</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>17665D60312637FC3C2207AEFD337BAD</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>C05B711322CA076AB9A57512649A029E</string>
+				<string>6C0CE301D9536F43B5C8E08E16712E38</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>18C6718FA411202146721CBD6539BA6A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Starscream-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1D9F765D7226F81517EEACB2B6EE02D6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6B923F40E09322629BC57536AFBDAB00</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>1DCE2224000629085D044E4A5FDB2710</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1DDD99058CD940FD5917CA5AD774B011</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>66A658DA4AA077462390CB0E887E48E5</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1EC0280E5CCCCD96F81E63B562E157DD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>SwiftyJSON.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1F6C69005CE5773E87D416DED050CEA8</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>6FE6036891606B3E61FED4812F318F99</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Development Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1FFCDC3F1D5C704D66044A14414886F5</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>0A3C59C66401164839B33852471AF8AF</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>22E6B7DDC8DADDE451326034FD9E9C8E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>55B757366E7A17818E9E92058B503641</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>23759C35F6314285C1D642E0F13B2BF3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>10E4A21EDDC41F94B30C17F38403E413</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>252588F94F9C2291A3486B7067E69576</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>259498FBDA923366A8452198A57D1F08</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>9957AD0715343BA2E7013691E1E98F7F</string>
+			<key>buildPhases</key>
+			<array>
+				<string>F2F5FF28F679ADC8A92B329DFCDCE51F</string>
+				<string>1FFCDC3F1D5C704D66044A14414886F5</string>
+				<string>74D6B9A88E9B97B956BF27CEE1DADAC3</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>48D042132AC259FD381EA4D96E17C5B5</string>
+				<string>396DE1C1608FD26AC267D36844C6630E</string>
+				<string>743E721F930E22D28C87A28227016A4E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>productName</key>
+			<string>Pods-FayeSwift_Tests</string>
+			<key>productReference</key>
+			<string>293CBC63DDF03144B25885047CA44A32</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>2692C5A026D6876DF0B8ED238232F2E6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>28E4BFBF9D2ACEADF06BE12B21BDFFBB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>293CBC63DDF03144B25885047CA44A32</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods_FayeSwift_Tests.framework</string>
+			<key>path</key>
+			<string>Pods_FayeSwift_Tests.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>2A14E4E75C0921B8190FF7805BDB1994</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftyJSON.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2A8281B38766D2C9957F19E11DA20796</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>FayeSwift.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2B196DA7A8C6F18B3AB9B0D2CA7C570E</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Starscream/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Starscream/Starscream.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>Starscream</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>2D4EF06156597B9C0C9800347C3343FC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
+				<string>FB45FFD90572718D82AB9092B750F0CA</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>2FDDE3F7149F856AAB928833D5658DB3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>WebsocketTransport.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2FE9E957D59ADA0A662E4B8C1A7BD7E2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>334521CDCF3F9A42442BD9C944494648</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+			<key>targetProxy</key>
+			<string>002C971AF7CA74392977401F3B5915E3</string>
+		</dict>
+		<key>344AD1F5AB3B588C01B21778050F2EAF</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+			<key>targetProxy</key>
+			<string>85FD64D2BAA74EAEF9935526FAFB1516</string>
+		</dict>
+		<key>37D9B4C012C932EED434E89C515FA960</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>38A444149F18F886FD0A1E23B45D6671</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>SSLSecurity.swift</string>
+			<key>path</key>
+			<string>Source/SSLSecurity.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3928AADA2DE31A1110577AFF292046A8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>FayeSwift-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>396DE1C1608FD26AC267D36844C6630E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>target</key>
+			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+			<key>targetProxy</key>
+			<string>252588F94F9C2291A3486B7067E69576</string>
+		</dict>
+		<key>3BD0A2C746E213094BBD1A609EE7575F</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>72A65D8E20A55005994AAC51F0764161</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>3E94F4BAAE418F28A0730CC56D7FACFF</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Starscream.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>4471A15D81938B6C2CE6A161EC41FEED</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>47C7E36F0C36BF6A9B7F26250E6F35CA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Starscream-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>47C81FB96686C0BE581D0FC3090AFC0D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Starscream.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4885D84AE492246F7B92A35D5F4C2787</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>48BC61B70DBB2FA057A57FF358488F76</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>0813DA1F91E6465D940389B245DB41E4</string>
+				<string>9BE8F84C840D474BB60E62D4A8259C63</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>path</key>
+			<string>SwiftyJSON</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>48D042132AC259FD381EA4D96E17C5B5</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>target</key>
+			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
+			<key>targetProxy</key>
+			<string>B1C1530B6651528BC37303CE7401BF99</string>
+		</dict>
+		<key>4AB2D41C9043F185BD735AC2476F72C6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4D7A0A0B35C6A6AD7E9E0865060EEF5F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>iOS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4F6AB79FA2ADEC11423A3782E26DC919</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3928AADA2DE31A1110577AFF292046A8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>5205B3C8BA6B671C4778F40FFC7FA2AC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F802A9E96DB8EBC2F1E349E2B2CD7D0A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>539B253953115DAEA00D55C65474A1F6</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>E09B4B87B5F08505B3484854BDF5F693</string>
+				<string>A031FE4B914D5D75EED52D5B6438B92F</string>
+				<string>B61129D4F667E387188D25F633E0B629</string>
+				<string>F802A9E96DB8EBC2F1E349E2B2CD7D0A</string>
+				<string>BA68C21BEA9C15F85E840F5BCD06B262</string>
+				<string>2FDDE3F7149F856AAB928833D5658DB3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Sources</string>
+			<key>path</key>
+			<string>Sources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>55B757366E7A17818E9E92058B503641</key>
+		<dict>
+			<key>fileRef</key>
+			<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>57072CFE2F97B4E7645A18D9267BA425</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CFB3E404A66EE13E14582416D200A72C</string>
+				<string>ED0A84AABA966E6DE908E1D84ABB429E</string>
+				<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+				<string>18C6718FA411202146721CBD6539BA6A</string>
+				<string>47C7E36F0C36BF6A9B7F26250E6F35CA</string>
+				<string>D47E6B74B427A4904D75990D1C34E829</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Starscream</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5744E51CF8ECA084D92426D57DC945EF</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>4F6AB79FA2ADEC11423A3782E26DC919</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>5B06E0872ABFC40563F3AA7BC14A699F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>38A444149F18F886FD0A1E23B45D6671</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>5B81CC02BA5C8A6F2E0D126266A157A1</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>D529A91B72E7AAA62AEB5E5A0E3A7114</string>
+				<string>BCCAAFB3C077A4CC7BD755B218914AF6</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>5CA1401B9C2AC9B84FD288DB6C3FC702</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>84EF024683CD3AA877927D77BAABE64F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>5D1E5C8AB017A941ACA43B001D23BCFA</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>72A65D8E20A55005994AAC51F0764161</string>
+			<key>targetProxy</key>
+			<string>E641FD10F82298D81E564BF16487B827</string>
+		</dict>
+		<key>5E2995BA89319C883FC5F6B5525881A2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>F8555866B482E99822581ABC579F3CD5</string>
+				<string>7B376196BBC05D9BB79CB4D466E47F1A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>64F09C054760D010B8E1B3BEB4671267</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods_FayeSwift_Example.framework</string>
+			<key>path</key>
+			<string>Pods_FayeSwift_Example.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>66A658DA4AA077462390CB0E887E48E5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>6A4FCAF5C9B5FE17B150653EFC153B3C</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>2B196DA7A8C6F18B3AB9B0D2CA7C570E</string>
+				<string>AAE3D93BCF9437209130DA54E4664DD3</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>6B923F40E09322629BC57536AFBDAB00</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SwiftyJSON-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6C0CE301D9536F43B5C8E08E16712E38</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>2692C5A026D6876DF0B8ED238232F2E6</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Example</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>6CF3F2DD66CD874F21BF38ED13DD0295</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
+			<key>remoteInfo</key>
+			<string>FayeSwift</string>
+		</dict>
+		<key>6DCD25231745CBB7A0DE8AE144F32C35</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SwiftyJSON-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6E1FB52B709CB783F4109CA61174C28B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6F6B01E4869FC29404539D1F7EA47967</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>5B06E0872ABFC40563F3AA7BC14A699F</string>
+				<string>C5681A6362FFDCE2DECBDEE5BFBC907C</string>
+				<string>E5F282A8CE41FC1844203FB427A39226</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>6FE6036891606B3E61FED4812F318F99</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>539B253953115DAEA00D55C65474A1F6</string>
+				<string>DC2BFC3D7A2C4C8331A638C7C1007D20</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>path</key>
+			<string>../..</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>70D1C0428C900D6671409303C06593E3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BA68C21BEA9C15F85E840F5BCD06B262</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>71A71AB65AF6D4590B241277504532F1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A031FE4B914D5D75EED52D5B6438B92F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>72A65D8E20A55005994AAC51F0764161</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>EE4323D789F482019F76D08873013AC9</string>
+			<key>buildPhases</key>
+			<array>
+				<string>5E2995BA89319C883FC5F6B5525881A2</string>
+				<string>1DDD99058CD940FD5917CA5AD774B011</string>
+				<string>DA4D3B670D373E4D9F2C0E061EF8C589</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>productName</key>
+			<string>SwiftyJSON</string>
+			<key>productReference</key>
+			<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>743E721F930E22D28C87A28227016A4E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>72A65D8E20A55005994AAC51F0764161</string>
+			<key>targetProxy</key>
+			<string>A1B59F9DF18152F704FE8F577A69E455</string>
+		</dict>
+		<key>74D6B9A88E9B97B956BF27CEE1DADAC3</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>23759C35F6314285C1D642E0F13B2BF3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>77F9AA324F09A90FB80ECB48C4E4BA1A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7B376196BBC05D9BB79CB4D466E47F1A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0813DA1F91E6465D940389B245DB41E4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>7DB346D0F39D3F0E887471402A8071AB</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
+				<string>1F6C69005CE5773E87D416DED050CEA8</string>
+				<string>0DB5BD81DCAEB161F8916282ABFD3340</string>
+				<string>0C03422930E80D7BB92C5C859589F09F</string>
+				<string>9A590701475CDEC7488348815ADACCBC</string>
+				<string>000A61D7F0D0221F20F470656F297E70</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8201936B74D25F4E7B4C6525D2B93E83</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>FayeSwift.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>84EF024683CD3AA877927D77BAABE64F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>85FD64D2BAA74EAEF9935526FAFB1516</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+			<key>remoteInfo</key>
+			<string>Starscream</string>
+		</dict>
+		<key>87D64F48FA18233694918281C87E0266</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>WebSocket.swift</string>
+			<key>path</key>
+			<string>Source/WebSocket.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9228804A5CB29EF1E2D8F805F0EEA281</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Starscream.framework</string>
+			<key>path</key>
+			<string>Starscream.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9361BD7539E0A621237603846E00D81E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>F1C91701EDE25A8DF650080551A1EE5F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>968A19F12E6EEAFE1AF4E01F94F08D05</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8D637FB9D47D77BBA1D7A37CE57E05F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>97A4D1CD8C418326C4A40D8446A9BAC8</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SwiftyJSON</string>
+			<key>target</key>
+			<string>72A65D8E20A55005994AAC51F0764161</string>
+			<key>targetProxy</key>
+			<string>3BD0A2C746E213094BBD1A609EE7575F</string>
+		</dict>
+		<key>9957AD0715343BA2E7013691E1E98F7F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>9D3BE8B79BE19FBE664EBECF0B50D300</string>
+				<string>BA99F75B86D32E8C1D12F5167359D6E2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>9A1314F41D4AF302873CCAE4DF95096E</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftyJSON.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9A590701475CDEC7488348815ADACCBC</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
+				<string>64F09C054760D010B8E1B3BEB4671267</string>
+				<string>293CBC63DDF03144B25885047CA44A32</string>
+				<string>9228804A5CB29EF1E2D8F805F0EEA281</string>
+				<string>B267AB921ABBC8B1A9D9D568D0D05615</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9BE8F84C840D474BB60E62D4A8259C63</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>E6671F9532A947F40918CF9A0D44F70F</string>
+				<string>2A14E4E75C0921B8190FF7805BDB1994</string>
+				<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+				<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
+				<string>0F0AD0445D068E37E1C8498A3BF6150D</string>
+				<string>6B923F40E09322629BC57536AFBDAB00</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/SwiftyJSON</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9D3BE8B79BE19FBE664EBECF0B50D300</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>D26B5E2282A330BE919FE4EFDFB738B3</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Tests</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>A031FE4B914D5D75EED52D5B6438B92F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeClientDelegate.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A07DDD4070D07F0518CC9913F4C9E2D6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B61129D4F667E387188D25F633E0B629</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>A1B59F9DF18152F704FE8F577A69E455</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>72A65D8E20A55005994AAC51F0764161</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>A64AB5E2E8029DC851944646B9BCCBB2</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>5B81CC02BA5C8A6F2E0D126266A157A1</string>
+			<key>buildPhases</key>
+			<array>
+				<string>EB11F02CBEFF194F4C17D9EFC26470D6</string>
+				<string>C5F66B163042240ECC70017F4B2423C7</string>
+				<string>5744E51CF8ECA084D92426D57DC945EF</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>334521CDCF3F9A42442BD9C944494648</string>
+				<string>97A4D1CD8C418326C4A40D8446A9BAC8</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>FayeSwift</string>
+			<key>productName</key>
+			<string>FayeSwift</string>
+			<key>productReference</key>
+			<string>B67F6FB5E88D459FDF1CC4FD93CB5D6B</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>A9DB76C98B77BAC9C5FB4172E70966EB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3E94F4BAAE418F28A0730CC56D7FACFF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>AAE3D93BCF9437209130DA54E4664DD3</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>47C81FB96686C0BE581D0FC3090AFC0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Starscream/Starscream-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Starscream/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Starscream/Starscream.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>Starscream</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>AEC58E9B2FE610C5D55CBB2FA4D34F2A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>6E1FB52B709CB783F4109CA61174C28B</string>
+				<string>37D9B4C012C932EED434E89C515FA960</string>
+				<string>4471A15D81938B6C2CE6A161EC41FEED</string>
+				<string>B29C7FFE8D08A56E77C644C03000FC94</string>
+				<string>2FE9E957D59ADA0A662E4B8C1A7BD7E2</string>
+				<string>14B7C4FE824293ABEEF592A7E71C4AFC</string>
+				<string>4885D84AE492246F7B92A35D5F4C2787</string>
+				<string>06B16C30B7CF62C246F4DD2B6BA325D2</string>
+				<string>B661AAF1FC01F5B9EB53567F4990C215</string>
+				<string>2692C5A026D6876DF0B8ED238232F2E6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-FayeSwift_Example</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B0F7AB6108413A1758B2F2D999AED350</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>17665D60312637FC3C2207AEFD337BAD</string>
+			<key>buildPhases</key>
+			<array>
+				<string>5CA1401B9C2AC9B84FD288DB6C3FC702</string>
+				<string>E307332C7150A001B3765B245D2D6839</string>
+				<string>22E6B7DDC8DADDE451326034FD9E9C8E</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>050F3648989E5C1D6979F7A0EDAA352A</string>
+				<string>344AD1F5AB3B588C01B21778050F2EAF</string>
+				<string>5D1E5C8AB017A941ACA43B001D23BCFA</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>productName</key>
+			<string>Pods-FayeSwift_Example</string>
+			<key>productReference</key>
+			<string>64F09C054760D010B8E1B3BEB4671267</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>B1C1530B6651528BC37303CE7401BF99</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
+			<key>remoteInfo</key>
+			<string>FayeSwift</string>
+		</dict>
+		<key>B267AB921ABBC8B1A9D9D568D0D05615</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>SwiftyJSON.framework</string>
+			<key>path</key>
+			<string>SwiftyJSON.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>B29C7FFE8D08A56E77C644C03000FC94</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B60722EF6A0F9DCD2D7C6D03F8B362CD</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>38A444149F18F886FD0A1E23B45D6671</string>
+				<string>87D64F48FA18233694918281C87E0266</string>
+				<string>57072CFE2F97B4E7645A18D9267BA425</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Starscream</string>
+			<key>path</key>
+			<string>Starscream</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B61129D4F667E387188D25F633E0B629</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>NSError+Helper.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B661AAF1FC01F5B9EB53567F4990C215</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Example.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B67F6FB5E88D459FDF1CC4FD93CB5D6B</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>FayeSwift.framework</string>
+			<key>path</key>
+			<string>FayeSwift.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>B8D637FB9D47D77BBA1D7A37CE57E05F</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>B9BD316B84610E564DEC11C4F736BD36</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>name</key>
+			<string>Podfile</string>
+			<key>path</key>
+			<string>../Podfile</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.ruby</string>
+		</dict>
+		<key>BA68C21BEA9C15F85E840F5BCD06B262</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>Transport.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BA99F75B86D32E8C1D12F5167359D6E2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>4AB2D41C9043F185BD735AC2476F72C6</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Tests/Pods-FayeSwift_Tests.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Tests</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>BB8D9E76FCCFA23D18222577B77988FB</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SwiftyJSON/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>SwiftyJSON</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>BCCAAFB3C077A4CC7BD755B218914AF6</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8201936B74D25F4E7B4C6525D2B93E83</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/FayeSwift/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>FayeSwift</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>C05B711322CA076AB9A57512649A029E</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>B661AAF1FC01F5B9EB53567F4990C215</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods-FayeSwift_Example/Pods-FayeSwift_Example.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods_FayeSwift_Example</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>C3E208C52EE6C8C0689C1B94807309CD</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>28E4BFBF9D2ACEADF06BE12B21BDFFBB</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>C5681A6362FFDCE2DECBDEE5BFBC907C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>18C6718FA411202146721CBD6539BA6A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>C5F66B163042240ECC70017F4B2423C7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>112044DE1A7A5E8036447F0CC4CA58CB</string>
+				<string>A9DB76C98B77BAC9C5FB4172E70966EB</string>
+				<string>0D76A5AF0D4781BFAC4D92B66E3A30B4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CB53D08DB5954932A4741A1969F2C195</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1EC0280E5CCCCD96F81E63B562E157DD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SwiftyJSON/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SwiftyJSON/SwiftyJSON.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>SwiftyJSON</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>CFB3E404A66EE13E14582416D200A72C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D26B5E2282A330BE919FE4EFDFB738B3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D33279C9153C75C4AD5A47272F4E6BA8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>FayeSwift-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D41D8CD98F00B204E9800998ECF8427E</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0700</string>
+				<key>LastUpgradeCheck</key>
+				<string>0700</string>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>7DB346D0F39D3F0E887471402A8071AB</string>
+			<key>productRefGroup</key>
+			<string>9A590701475CDEC7488348815ADACCBC</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>A64AB5E2E8029DC851944646B9BCCBB2</string>
+				<string>B0F7AB6108413A1758B2F2D999AED350</string>
+				<string>259498FBDA923366A8452198A57D1F08</string>
+				<string>0FFB2621535432DEA9289D0F9EEEE26C</string>
+				<string>72A65D8E20A55005994AAC51F0764161</string>
+			</array>
+		</dict>
+		<key>D47E6B74B427A4904D75990D1C34E829</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Starscream-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D529A91B72E7AAA62AEB5E5A0E3A7114</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8201936B74D25F4E7B4C6525D2B93E83</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/FayeSwift/FayeSwift-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/FayeSwift/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/FayeSwift/FayeSwift.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>FayeSwift</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>D7AD1CA221F811429F2397EA408725EE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1DCE2224000629085D044E4A5FDB2710</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA4D3B670D373E4D9F2C0E061EF8C589</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>1D9F765D7226F81517EEACB2B6EE02D6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DC2BFC3D7A2C4C8331A638C7C1007D20</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>2A8281B38766D2C9957F19E11DA20796</string>
+				<string>8201936B74D25F4E7B4C6525D2B93E83</string>
+				<string>D33279C9153C75C4AD5A47272F4E6BA8</string>
+				<string>FA96A146A7D76D7C1EEA5F97736E1F0D</string>
+				<string>3928AADA2DE31A1110577AFF292046A8</string>
+				<string>77F9AA324F09A90FB80ECB48C4E4BA1A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>Example/Pods/Target Support Files/FayeSwift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E09B4B87B5F08505B3484854BDF5F693</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>FayeClient.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E307332C7150A001B3765B245D2D6839</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>968A19F12E6EEAFE1AF4E01F94F08D05</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>E4E07C18061452192A8755C57422BE93</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E5F282A8CE41FC1844203FB427A39226</key>
+		<dict>
+			<key>fileRef</key>
+			<string>87D64F48FA18233694918281C87E0266</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>E641FD10F82298D81E564BF16487B827</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>72A65D8E20A55005994AAC51F0764161</string>
+			<key>remoteInfo</key>
+			<string>SwiftyJSON</string>
+		</dict>
+		<key>E6671F9532A947F40918CF9A0D44F70F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EB11F02CBEFF194F4C17D9EFC26470D6</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>172D87FC5B15E2E05E643DD1188F953D</string>
+				<string>71A71AB65AF6D4590B241277504532F1</string>
+				<string>FF0CA1F99F12CC1A9B852F6601921D99</string>
+				<string>A07DDD4070D07F0518CC9913F4C9E2D6</string>
+				<string>5205B3C8BA6B671C4778F40FFC7FA2AC</string>
+				<string>70D1C0428C900D6671409303C06593E3</string>
+				<string>F465C9735101FE983DA25543F4066F9A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>ED0A84AABA966E6DE908E1D84ABB429E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Starscream.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EE4323D789F482019F76D08873013AC9</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>BB8D9E76FCCFA23D18222577B77988FB</string>
+				<string>CB53D08DB5954932A4741A1969F2C195</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>F1C91701EDE25A8DF650080551A1EE5F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D47E6B74B427A4904D75990D1C34E829</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F2F5FF28F679ADC8A92B329DFCDCE51F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>D7AD1CA221F811429F2397EA408725EE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F3FCAA0DF279AAE5F2E8878F0749DD44</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods-FayeSwift_Tests.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F465C9735101FE983DA25543F4066F9A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2FDDE3F7149F856AAB928833D5658DB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-w -Xanalyzer -analyzer-disable-all-checks</string>
+			</dict>
+		</dict>
+		<key>F802A9E96DB8EBC2F1E349E2B2CD7D0A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>StringExtensions.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F8555866B482E99822581ABC579F3CD5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6DCD25231745CBB7A0DE8AE144F32C35</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>FA96A146A7D76D7C1EEA5F97736E1F0D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>FayeSwift-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FB45FFD90572718D82AB9092B750F0CA</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>RELEASE=1</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>FF0CA1F99F12CC1A9B852F6601921D99</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D33279C9153C75C4AD5A47272F4E6BA8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>D41D8CD98F00B204E9800998ECF8427E</string>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '91641611ED941D25E7E423DB'
-               BlueprintName = 'FayeSwift'
-               ReferencedContainer = 'container:Pods.xcodeproj'
-               BuildableName = 'FayeSwift.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A64AB5E2E8029DC851944646B9BCCBB2"
+               BuildableName = "FayeSwift.framework"
+               BlueprintName = "FayeSwift"
+               ReferencedContainer = "container:Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -38,17 +41,25 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A64AB5E2E8029DC851944646B9BCCBB2"
+            BuildableName = "FayeSwift.framework"
+            BlueprintName = "FayeSwift"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
@@ -1,39 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "YES">
             <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A64AB5E2E8029DC851944646B9BCCBB2"
-               BuildableName = "FayeSwift.framework"
-               BlueprintName = "FayeSwift"
-               ReferencedContainer = "container:Pods.xcodeproj">
+               BuildableIdentifier = 'primary'
+               BlueprintIdentifier = '294A4FA46CFBB19E53DCBEEE'
+               BlueprintName = 'FayeSwift'
+               ReferencedContainer = 'container:Pods.xcodeproj'
+               BuildableName = 'FayeSwift.framework'>
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -41,25 +38,17 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A64AB5E2E8029DC851944646B9BCCBB2"
-            BuildableName = "FayeSwift.framework"
-            BlueprintName = "FayeSwift"
-            ReferencedContainer = "container:Pods.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'A222085FA26FD4500364F00F'
+               BlueprintIdentifier = '9FE8D2134771AB8BDBA5EA68'
                BlueprintName = 'FayeSwift'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'FayeSwift.framework'>

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'C22F1607892CC69A3C9E90E5'
+               BlueprintIdentifier = '91641611ED941D25E7E423DB'
                BlueprintName = 'FayeSwift'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'FayeSwift.framework'>

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/FayeSwift.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '294A4FA46CFBB19E53DCBEEE'
+               BlueprintIdentifier = 'A222085FA26FD4500364F00F'
                BlueprintName = 'FayeSwift'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'FayeSwift.framework'>

--- a/Example/Pods/Starscream/README.md
+++ b/Example/Pods/Starscream/README.md
@@ -4,13 +4,10 @@ Starscream is a conforming WebSocket ([RFC 6455](http://tools.ietf.org/html/rfc6
 
 It's Objective-C counter part can be found here: [Jetfire](https://github.com/acmacalister/jetfire)
 
-This is written Swift 2. (the latest). If you need older legecy support checkout the Swift-1.2 branch [here](https://github.com/daltoniam/Starscream/tree/swift-1.2).
-
 ## Features
 
 - Conforms to all of the base [Autobahn test suite](http://autobahn.ws/testsuite/).
 - Nonblocking. Everything happens in the background, thanks to GCD.
-- Simple delegate pattern design.
 - TLS/WSS support.
 - Simple concise codebase at just a few hundred LOC.
 
@@ -22,10 +19,10 @@ First thing is to import the framework. See the Installation instructions on how
 import Starscream
 ```
 
-Once imported, you can open a connection to your WebSocket server. Note that `socket` is probably best as a property, so your delegate can stick around.
+Once imported, you can open a connection to your WebSocket server. Note that `socket` is probably best as a property, so it doesn't get deallocated right after being setup.
 
 ```swift
-var socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!)
+socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!)
 socket.delegate = self
 socket.connect()
 ```
@@ -38,7 +35,7 @@ websocketDidConnect is called as soon as the client connects to the server.
 
 ```swift
 func websocketDidConnect(socket: WebSocket) {
-    println("websocket is connected")
+    print("websocket is connected")
 }
 ```
 
@@ -48,7 +45,7 @@ websocketDidDisconnect is called as soon as the client is disconnected from the 
 
 ```swift
 func websocketDidDisconnect(socket: WebSocket, error: NSError?) {
-	println("websocket is disconnected: \(error?.localizedDescription)")
+	print("websocket is disconnected: \(error?.localizedDescription)")
 }
 ```
 
@@ -58,7 +55,7 @@ websocketDidReceiveMessage is called when the client gets a text frame from the 
 
 ```swift
 func websocketDidReceiveMessage(socket: WebSocket, text: String) {
-	println("got some text: \(text)")
+	print("got some text: \(text)")
 }
 ```
 
@@ -68,7 +65,7 @@ websocketDidReceiveData is called when the client gets a binary frame from the c
 
 ```swift
 func websocketDidReceiveData(socket: WebSocket, data: NSData) {
-	println("got some data: \(data.length)")
+	print("got some data: \(data.length)")
 }
 ```
 
@@ -78,29 +75,29 @@ websocketDidReceivePong is called when the client gets a pong response from the 
 
 ```swift
 func websocketDidReceivePong(socket: WebSocket) {
-	println("Got pong!")
+	print("Got pong!")
 }
 ```
 
 Or you can use closures.
 
 ```swift
-var socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!)
+socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!)
 //websocketDidConnect
 socket.onConnect = {
-    println("websocket is connected")
+    print("websocket is connected")
 }
 //websocketDidDisconnect
 socket.onDisconnect = { (error: NSError?) in
-    println("websocket is disconnected: \(error?.localizedDescription)")
+    print("websocket is disconnected: \(error?.localizedDescription)")
 }
 //websocketDidReceiveMessage
 socket.onText = { (text: String) in
-    println("got some text: \(text)")
+    print("got some text: \(text)")
 }
 //websocketDidReceiveData
 socket.onData = { (data: NSData) in
-    println("got some data: \(data.length)")
+    print("got some data: \(data.length)")
 }
 //you could do onPong as well.
 socket.connect()
@@ -114,7 +111,7 @@ socket.connect()
 The writeData method gives you a simple way to send `NSData` (binary) data to the server.
 
 ```swift
-self.socket.writeData(data) //write some NSData over the socket!
+socket.writeData(data) //write some NSData over the socket!
 ```
 
 ### writeString
@@ -122,7 +119,7 @@ self.socket.writeData(data) //write some NSData over the socket!
 The writeString method is the same as writeData, but sends text/string.
 
 ```swift
-self.socket.writeString("Hi Server!") //example on how to write text over the socket!
+socket.writeString("Hi Server!") //example on how to write text over the socket!
 ```
 
 ### writePing
@@ -130,7 +127,7 @@ self.socket.writeString("Hi Server!") //example on how to write text over the so
 The writePing method is the same as writeData, but sends a ping control frame.
 
 ```swift
-self.socket.writePing(NSData()) //example on how to write a ping control frame over the socket!
+socket.writePing(NSData()) //example on how to write a ping control frame over the socket!
 ```
 
 ### disconnect
@@ -138,7 +135,7 @@ self.socket.writePing(NSData()) //example on how to write a ping control frame o
 The disconnect method does what you would expect and closes the socket.
 
 ```swift
-self.socket.disconnect()
+socket.disconnect()
 ```
 
 ### isConnected
@@ -146,7 +143,7 @@ self.socket.disconnect()
 Returns if the socket is connected or not.
 
 ```swift
-if self.socket.isConnected {
+if socket.isConnected {
   // do cool stuff.
 }
 ```
@@ -167,7 +164,7 @@ If you need to specify a protocol, simple add it to the init:
 
 ```swift
 //chat and superchat are the example protocols here
-var socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
+socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
 socket.delegate = self
 socket.connect()
 ```
@@ -177,7 +174,7 @@ socket.connect()
 There are a couple of other properties that modify the stream:
 
 ```swift
-var socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
+socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
 
 //set this if you are planning on using the socket in a VOIP background setting (using the background VOIP service).
 socket.voipEnabled = true
@@ -191,7 +188,7 @@ socket.selfSignedSSL = true
 SSL Pinning is also supported in Starscream. 
 
 ```swift
-var socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
+socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
 let data = ... //load your certificate from disk
 socket.security = SSLSecurity(certs: [SSLCert(data: data)], usePublicKeys: true)
 //socket.security = SSLSecurity() //uses the .cer files in your app's bundle
@@ -203,7 +200,7 @@ You load either a `NSData` blob of your certificate or you can use a `SecKeyRef`
 A custom queue can be specified when delegate methods are called. By default `dispatch_get_main_queue` is used, thus making all delegate methods calls run on the main thread. It is important to note that all WebSocket processing is done on a background thread, only the delegate method calls are changed when modifying the queue. The actual processing is always on a background thread and will not pause your app.
 
 ```swift
-var socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
+socket = WebSocket(url: NSURL(string: "ws://localhost:8080/")!, protocols: ["chat","superchat"])
 //create a custom queue
 socket.queue = dispatch_queue_create("com.vluxe.starscream.myapp", nil)
 ```
@@ -214,21 +211,21 @@ Check out the SimpleTest project in the examples directory to see how to setup a
 
 ## Requirements
 
-Starscream works with iOS 7/OSX 10.9 or above. It is recommended to use iOS 8/10.10 or above for Cocoapods/framework support. To use Starscream with a project targeting iOS 7, you must include all Swift files directly in your project.
+Starscream works with iOS 7/OSX 10.9 or above. It is recommended to use iOS 8/10.10 or above for CocoaPods/framework support. To use Starscream with a project targeting iOS 7, you must include all Swift files directly in your project.
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 
 Check out [Get Started](http://cocoapods.org/) tab on [cocoapods.org](http://cocoapods.org/).
 
 To use Starscream in your project add the following 'Podfile' to your project
 
 	source 'https://github.com/CocoaPods/Specs.git'
-	platform :ios, '8.0'
+	platform :ios, '9.0'
 	use_frameworks!
 
-	pod 'Starscream', '~> 1.0.0'
+	pod 'Starscream', '~> 1.1.3'
 
 Then run:
 
@@ -250,7 +247,7 @@ $ brew install carthage
 To integrate Starscream into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```
-github "daltoniam/Starscream" >= 1.0.0
+github "daltoniam/Starscream" >= 1.1.3
 ```
 
 ### Rogue
@@ -277,8 +274,9 @@ If you are running this in an OSX app or on a physical iOS device you will need 
 
 ## TODOs
 
-- [ ] WatchOS
-- [ ] Add Unit Tests
+- [ ] WatchOS?
+- [ ] Linux Support?
+- [ ] Add Unit Tests - Local Swift websocket server
 
 ## License
 

--- a/Example/Pods/Starscream/Source/SSLSecurity.swift
+++ b/Example/Pods/Starscream/Source/SSLSecurity.swift
@@ -68,7 +68,8 @@ public class SSLSecurity {
     public convenience init(usePublicKeys: Bool = false) {
         let paths = NSBundle.mainBundle().pathsForResourcesOfType("cer", inDirectory: ".")
         
-        let certs = paths.reduce([SSLCert]()) { (var certs: [SSLCert], path: String) -> [SSLCert] in
+        let certs = paths.reduce([SSLCert]()) { (certs: [SSLCert], path: String) -> [SSLCert] in
+            var certs = certs
             if let data = NSData(contentsOfFile: path) {
                 certs.append(SSLCert(data: data))
             }
@@ -91,7 +92,8 @@ public class SSLSecurity {
         
         if self.usePublicKeys {
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0)) {
-                let pubKeys = certs.reduce([SecKeyRef]()) { (var pubKeys: [SecKeyRef], cert: SSLCert) -> [SecKeyRef] in
+                let pubKeys = certs.reduce([SecKeyRef]()) { (pubKeys: [SecKeyRef], cert: SSLCert) -> [SecKeyRef] in
+                    var pubKeys = pubKeys
                     if let data = cert.certData where cert.key == nil {
                         cert.key = self.extractPublicKey(data)
                     }
@@ -105,7 +107,8 @@ public class SSLSecurity {
                 self.isReady = true
             }
         } else {
-            let certificates = certs.reduce([NSData]()) { (var certificates: [NSData], cert: SSLCert) -> [NSData] in
+            let certificates = certs.reduce([NSData]()) { (certificates: [NSData], cert: SSLCert) -> [NSData] in
+                var certificates = certificates
                 if let data = cert.certData {
                     certificates.append(data)
                 }
@@ -167,7 +170,7 @@ public class SSLSecurity {
                 for serverCert in serverCerts {
                     for cert in certs {
                         if cert == serverCert {
-                            trustedCount++
+                            trustedCount += 1
                             break
                         }
                     }
@@ -219,7 +222,8 @@ public class SSLSecurity {
     - returns: the certificate chain for the trust
     */
     func certificateChainForTrust(trust: SecTrustRef) -> [NSData] {
-        let certificates = (0..<SecTrustGetCertificateCount(trust)).reduce([NSData]()) { (var certificates: [NSData], index: Int) -> [NSData] in
+        let certificates = (0..<SecTrustGetCertificateCount(trust)).reduce([NSData]()) { (certificates: [NSData], index: Int) -> [NSData] in
+            var certificates = certificates
             let cert = SecTrustGetCertificateAtIndex(trust, index)
             certificates.append(SecCertificateCopyData(cert!))
             return certificates
@@ -237,7 +241,8 @@ public class SSLSecurity {
     */
     func publicKeyChainForTrust(trust: SecTrustRef) -> [SecKeyRef] {
         let policy = SecPolicyCreateBasicX509()
-        let keys = (0..<SecTrustGetCertificateCount(trust)).reduce([SecKeyRef]()) { (var keys: [SecKeyRef], index: Int) -> [SecKeyRef] in
+        let keys = (0..<SecTrustGetCertificateCount(trust)).reduce([SecKeyRef]()) { (keys: [SecKeyRef], index: Int) -> [SecKeyRef] in
+            var keys = keys
             let cert = SecTrustGetCertificateAtIndex(trust, index)
             if let key = extractPublicKeyFromCert(cert!, policy: policy) {
                 keys.append(key)

--- a/Example/Pods/Target Support Files/FayeSwift/Info.plist
+++ b/Example/Pods/Target Support Files/FayeSwift/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>0.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/FayeSwift/Info.plist
+++ b/Example/Pods/Target Support Files/FayeSwift/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.2.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/FayeSwift/Info.plist
+++ b/Example/Pods/Target Support Files/FayeSwift/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>0.2.0</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.2.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Pods-FayeSwift_Example/Info.plist
+++ b/Example/Pods/Target Support Files/Pods-FayeSwift_Example/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Pods-FayeSwift_Example/Info.plist
+++ b/Example/Pods/Target Support Files/Pods-FayeSwift_Example/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Pods-FayeSwift_Tests/Info.plist
+++ b/Example/Pods/Target Support Files/Pods-FayeSwift_Tests/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Pods-FayeSwift_Tests/Info.plist
+++ b/Example/Pods/Target Support Files/Pods-FayeSwift_Tests/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Starscream/Info.plist
+++ b/Example/Pods/Target Support Files/Starscream/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.1.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Starscream/Info.plist
+++ b/Example/Pods/Target Support Files/Starscream/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.1.3</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.1.3</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Starscream/Info.plist
+++ b/Example/Pods/Target Support Files/Starscream/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.1.3</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.1.3</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/SwiftyJSON/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftyJSON/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>2.3.2</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.3.2</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/SwiftyJSON/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftyJSON/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>2.3.2</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2.3.2</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/FayeSwift.podspec
+++ b/FayeSwift.podspec
@@ -1,42 +1,22 @@
-#
-# Be sure to run `pod lib lint FayeSwift.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = "FayeSwift"
   s.version          = "0.2.0"
   s.summary          = "A pure Swift Faye (Bayeux) Client"
-
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
   s.description      = <<-DESC
                         A Pure Swift Client Library for the Faye (Bayeux/Comet) Pub-Sub messaging server.
                         This client has been tested with the Faye (http://faye.jcoglan.com) implementation of the
                         Bayeux protocol. Currently only supports Websocket transport.
                        DESC
-
   s.homepage         = "https://github.com/hamin/FayeSwift"
-  s.license          = 'MIT'
+  s.license          = "MIT"
   s.author           = { "Haris Amin" => "aminharis7@gmail.com" }
   s.source           = { :git => "https://github.com/hamin/FayeSwift.git", :tag => s.version.to_s }
-  s.social_media_url = 'https://twitter.com/harisamin'
-
+  s.social_media_url = "https://twitter.com/harisamin"
   s.requires_arc = true
   s.osx.deployment_target = "10.9"
   s.ios.deployment_target = "8.0"
-  # s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
-
-  #s.source_files = 'Pod/Classes/**/*'
   s.source_files = "Sources/*.swift"
-
-  s.dependency 'Starscream', '~> 1.1'
-  s.dependency 'SwiftyJSON', '~> 2.3'
+  s.dependency "Starscream"
+  s.dependency "SwiftyJSON"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,6 @@ let package = Package(
     targets: [],
     dependencies: [
         .Package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", versions: "2.3.3" ..< Version.max),
-		.Package(url: "https://github.com/daltoniam/Starscream.git", versions: "1.1.1" ..< Version.max)
+		.Package(url: "https://github.com/daltoniam/Starscream.git", versions: "1.1.3" ..< Version.max)
     ]
 )

--- a/Readme.md
+++ b/Readme.md
@@ -104,7 +104,7 @@ func didUnsubscribeFromChannel(client: FayeClient, channel: String) {
 The subscriptionFailedWithError method is called when the client fails to subscribe to a Faye channel.
 
 ```swift
-func subscriptionFailedWithError(client: FayeClient, error: String) {
+func subscriptionFailedWithError(client: FayeClient, error: subscriptionError) {
    println("SUBSCRIPTION FAILED!!!!")
 }
 ```

--- a/Sources/FayeClient+Action.swift
+++ b/Sources/FayeClient+Action.swift
@@ -1,0 +1,24 @@
+//
+//  FayeClient+Action.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 19/07/2016.
+//
+//
+
+import Foundation
+
+extension FayeClient {
+    
+    // MARK: Private - Timer Action
+    @objc
+    func pendingSubscriptionsAction(timer: NSTimer) {
+        guard fayeConnected == true else {
+            print("Faye: Failed to resubscribe to all pending channels, socket disconnected")
+            
+            return
+        }
+        
+        resubscribeToPendingSubscriptions()
+    }
+}

--- a/Sources/FayeClient+Bayuex.swift
+++ b/Sources/FayeClient+Bayuex.swift
@@ -1,0 +1,146 @@
+//
+//  FayeClient+Bayuex.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 19/07/2016.
+//
+//
+
+import Foundation
+import SwiftyJSON
+
+// MARK: Bayuex Connection Type
+public enum BayeuxConnection: String {
+    case LongPolling = "long-polling"
+    case Callback = "callback-polling"
+    case iFrame = "iframe"
+    case WebSocket = "websocket"
+}
+
+// MARK: BayuexChannel Messages
+public enum BayeuxChannel: String {
+    case Handshake = "/meta/handshake"
+    case Connect = "/meta/connect"
+    case Disconnect = "/meta/disconnect"
+    case Subscribe = "/meta/subscribe"
+    case Unsubscibe = "/meta/unsubscribe"
+}
+
+// MARK: Bayuex Parameters
+public enum Bayeux: String {
+    case Channel = "channel"
+    case Version = "version"
+    case ClientId = "clientId"
+    case ConnectionType = "connectionType"
+    case Data = "data"
+    case Subscription = "subscription"
+    case Id = "id"
+    case MinimumVersion = "minimumVersion"
+    case SupportedConnectionTypes = "supportedConnectionTypes"
+    case Successful = "successful"
+    case Error = "error"
+}
+
+// MARK: Private Bayuex Methods
+extension FayeClient {
+    
+    /**
+     Bayeux messages
+     */
+    
+    // Bayeux Handshake
+    // "channel": "/meta/handshake",
+    // "version": "1.0",
+    // "minimumVersion": "1.0beta",
+    // "supportedConnectionTypes": ["long-polling", "callback-polling", "iframe", "websocket]
+    func handshake() {
+        let connTypes:NSArray = [BayeuxConnection.LongPolling.rawValue, BayeuxConnection.Callback.rawValue, BayeuxConnection.iFrame.rawValue, BayeuxConnection.WebSocket.rawValue]
+        
+        var dict = [String: AnyObject]()
+        dict[Bayeux.Channel.rawValue] = BayeuxChannel.Handshake.rawValue
+        dict[Bayeux.Version.rawValue] = "1.0"
+        dict[Bayeux.MinimumVersion.rawValue] = "1.0beta"
+        dict[Bayeux.SupportedConnectionTypes.rawValue] = connTypes
+        
+        if let string = JSON(dict).rawString() {
+            self.transport?.writeString(string)
+        }
+    }
+    
+    // Bayeux Connect
+    // "channel": "/meta/connect",
+    // "clientId": "Un1q31d3nt1f13r",
+    // "connectionType": "long-polling"
+    func connect() {
+        let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Connect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue, "advice": ["timeout": 0]]
+        
+        if let string = JSON(dict).rawString() {
+            self.transport?.writeString(string)
+        }
+    }
+    
+    // Bayeux Disconnect
+    // "channel": "/meta/disconnect",
+    // "clientId": "Un1q31d3nt1f13r"
+    func disconnect() {
+        let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Disconnect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue]
+        if let string = JSON(dict).rawString() {
+            self.transport?.writeString(string)
+        }
+    }
+    
+    // Bayeux Subscribe
+    // "channel": "/meta/subscribe",
+    // "clientId": "Un1q31d3nt1f13r",
+    // "subscription": "/foo/**"
+    func subscribe(var model:FayeSubscriptionModel) {
+        do {
+            let json = try model.jsonString()
+            
+            self.transport?.writeString(json)
+            self.pendingSubscriptions.append(model)
+        } catch FayeSubscriptionModelError.ConversationError {
+            
+        } catch FayeSubscriptionModelError.ClientIdNotValid where fayeClientId?.characters.count > 0 {
+            model.clientId = fayeClientId
+            subscribe(model)
+        } catch {
+            
+        }
+    }
+    
+    // Bayeux Unsubscribe
+    // {
+    // "channel": "/meta/unsubscribe",
+    // "clientId": "Un1q31d3nt1f13r",
+    // "subscription": "/foo/**"
+    // }
+    func unsubscribe(channel:String) {
+        if let clientId = self.fayeClientId {
+            let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Unsubscibe.rawValue, Bayeux.ClientId.rawValue: clientId, Bayeux.Subscription.rawValue: channel]
+            if let string = JSON(dict).rawString() {
+                self.transport?.writeString(string)
+            }
+        }
+    }
+    
+    // Bayeux Publish
+    // {
+    // "channel": "/some/channel",
+    // "clientId": "Un1q31d3nt1f13r",
+    // "data": "some application string or JSON encoded object",
+    // "id": "some unique message id"
+    // }
+    func publish(data:[String:AnyObject], channel:String) {
+        if self.fayeConnected == true {
+            let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: channel, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.Id.rawValue: self.nextMessageId(), Bayeux.Data.rawValue: data]
+            
+            if let string = JSON(dict).rawString() {
+                print("Faye: Publish string: \(string)")
+                self.transport?.writeString(string)
+            }
+        } else {
+            // Faye is not connected
+        }
+    }
+}

--- a/Sources/FayeClient+Bayuex.swift
+++ b/Sources/FayeClient+Bayuex.swift
@@ -39,6 +39,7 @@ public enum Bayeux: String {
     case SupportedConnectionTypes = "supportedConnectionTypes"
     case Successful = "successful"
     case Error = "error"
+    case Advice = "advice"
 }
 
 // MARK: Private Bayuex Methods
@@ -75,7 +76,7 @@ extension FayeClient {
     // "connectionType": "long-polling"
     func connect() {
         dispatch_sync(writeOperationQueue) { [unowned self] in
-            let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Connect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue, "advice": ["timeout": 0]]
+            let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Connect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue, Bayeux.Advice.rawValue: ["timeout": self.timeOut]]
             
             if let string = JSON(dict).rawString() {
                 self.transport?.writeString(string)

--- a/Sources/FayeClient+Bayuex.swift
+++ b/Sources/FayeClient+Bayuex.swift
@@ -100,7 +100,7 @@ extension FayeClient {
     // "clientId": "Un1q31d3nt1f13r",
     // "subscription": "/foo/**"
     func subscribe(var model:FayeSubscriptionModel) {
-        dispatch_async(writeOperationQueue) { [unowned self] in
+        dispatch_sync(writeOperationQueue) { [unowned self] in
             do {
                 let json = try model.jsonString()
                 
@@ -144,7 +144,7 @@ extension FayeClient {
     // "id": "some unique message id"
     // }
     func publish(data:[String:AnyObject], channel:String) {
-        dispatch_async(writeOperationQueue) { [weak self] in
+        dispatch_sync(writeOperationQueue) { [weak self] in
             if let clientId = self?.fayeClientId, messageId = self?.nextMessageId()
                 where self?.fayeConnected == true {
                 let dict:[String:AnyObject] = [

--- a/Sources/FayeClient+Helper.swift
+++ b/Sources/FayeClient+Helper.swift
@@ -1,0 +1,21 @@
+//
+//  FayeClient+Helper.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 19/07/2016.
+//
+//
+
+import Foundation
+
+extension FayeClient {
+    
+    // MARK: Helper
+    public func isSubscribedToChannel(channel:String) -> Bool {
+        return self.openSubscriptions.contains { $0.subscription == channel }
+    }
+    
+    public func isTransportConnected() -> Bool {
+        return self.transport!.isConnected()
+    }
+}

--- a/Sources/FayeClient+Helper.swift
+++ b/Sources/FayeClient+Helper.swift
@@ -8,13 +8,16 @@
 
 import Foundation
 
-extension FayeClient {
+public extension FayeClient {
     
     // MARK: Helper
+    
+    ///  Validate whatever a subscription has been subscribed correctly 
     public func isSubscribedToChannel(channel:String) -> Bool {
         return self.openSubscriptions.contains { $0.subscription == channel }
     }
     
+    ///  Validate faye transport is connected
     public func isTransportConnected() -> Bool {
         return self.transport!.isConnected()
     }

--- a/Sources/FayeClient+Parsing.swift
+++ b/Sources/FayeClient+Parsing.swift
@@ -1,0 +1,108 @@
+//
+//  FayeClient+Parsing.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 19/07/2016.
+//
+//
+
+import Foundation
+import SwiftyJSON
+
+extension FayeClient {
+   
+    // MARK:
+    // MARK: Parsing
+
+    func parseFayeMessage(messageJSON:JSON) {
+        let messageDict = messageJSON[0]
+        if let channel = messageDict[Bayeux.Channel.rawValue].string {
+            
+            // Handle Meta Channels
+            if let metaChannel = BayeuxChannel(rawValue: channel) {
+                switch(metaChannel) {
+                case .Handshake:
+                    self.fayeClientId = messageDict[Bayeux.ClientId.rawValue].stringValue
+                    if messageDict[Bayeux.Successful.rawValue].int == 1 {
+                        self.delegate?.connectedToServer(self)
+                        self.fayeConnected = true;
+                        self.connect()
+                        self.subscribeQueuedSubscriptions()
+                        pendingSubscriptionSchedule.valid
+                    } else {
+                        // OOPS
+                    }
+                case .Connect:
+                    if messageDict[Bayeux.Successful.rawValue].int == 1 {
+                        self.fayeConnected = true;
+                        self.connect()
+                    } else {
+                        // OOPS
+                    }
+                case .Disconnect:
+                    if messageDict[Bayeux.Successful.rawValue].int == 1 {
+                        self.fayeConnected = false;
+                        self.transport?.closeConnection()
+                        self.delegate?.disconnectedFromServer(self)
+                    } else {
+                        // OOPS
+                    }
+                case .Subscribe:
+                    if let success = messageJSON[0][Bayeux.Successful.rawValue].int where success == 1 {
+                        if let subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
+                            removeChannelFromPendingSubscriptions(subscription)
+                            
+                            self.openSubscriptions.append(FayeSubscriptionModel(subscription: subscription, clientId: fayeClientId))
+                            self.delegate?.didSubscribeToChannel(self, channel: subscription)
+                        } else {
+                            print("Faye: Missing subscription for Subscribe")
+                        }
+                    } else {
+                        // Subscribe Failed
+                        if let error = messageJSON[0][Bayeux.Error.rawValue].string,
+                            subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
+                            removeChannelFromPendingSubscriptions(subscription)
+                            
+                            self.delegate?.subscriptionFailedWithError(
+                                self,
+                                error: subscriptionError.error(subscription: subscription, error: error)
+                            )
+                        }
+                    }
+                case .Unsubscibe:
+                    if let subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
+                        removeChannelFromOpenSubscriptions(subscription)
+                        self.delegate?.didUnsubscribeFromChannel(self, channel: subscription)
+                    } else {
+                        print("Faye: Missing subscription for Unsubscribe")
+                    }
+                }
+            } else {
+                // Handle Client Channel
+                if self.isSubscribedToChannel(channel) {
+                    if messageJSON[0][Bayeux.Data.rawValue] != JSON.null {
+                        let data: AnyObject = messageJSON[0][Bayeux.Data.rawValue].object
+                        
+                        if let channelBlock = self.channelSubscriptionBlocks[channel] {
+                            channelBlock(data as! NSDictionary)
+                        } else {
+                            print("Faye: Failed to get channel block for : \(channel)")
+                        }
+                        
+                        self.delegate?.messageReceived(
+                            self,
+                            messageDict: data as! NSDictionary,
+                            channel: channel
+                        )
+                    } else {
+                        print("Faye: For some reason data is nil for channel: \(channel)")
+                    }
+                } else {
+                    print("Faye: Weird channel that not been set to subscribed: \(channel)")
+                }
+            }
+        } else {
+            print("Faye: Missing channel for \(messageDict)")
+        }
+    }
+}

--- a/Sources/FayeClient+Subscriptions.swift
+++ b/Sources/FayeClient+Subscriptions.swift
@@ -47,7 +47,7 @@ extension FayeClient {
     }
     
     func receive(message: String) {
-        dispatch_async(readOperationQueue) { [unowned self] in
+        dispatch_sync(readOperationQueue) { [unowned self] in
             if let jsonData = message.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
                 let json = JSON(data: jsonData)
                 

--- a/Sources/FayeClient+Subscriptions.swift
+++ b/Sources/FayeClient+Subscriptions.swift
@@ -11,6 +11,7 @@ import SwiftyJSON
 
 // MARK: Private Internal methods
 extension FayeClient {
+    
     func subscribeQueuedSubscriptions() {
         // if there are any outstanding open subscriptions resubscribe
         for channel in self.queuedSubscriptions {
@@ -34,18 +35,24 @@ extension FayeClient {
         all.forEach({ unsubscribeFromChannel($0.subscription) })
     }
     
+    // MARK:
+    // MARK: Send/Receive
+
     func send(message: NSDictionary) {
-        // Parse JSON
-        if let string = JSON(message).rawString() {
-            self.transport?.writeString(string)
+        dispatch_async(writeOperationQueue) { [unowned self] in
+            if let string = JSON(message).rawString() {
+                self.transport?.writeString(string)
+            }
         }
     }
     
     func receive(message: String) {
-        // Parse JSON
-        if let jsonData = message.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
-            let json = JSON(data: jsonData)
-            self.parseFayeMessage(json)
+        dispatch_async(readOperationQueue) { [unowned self] in
+            if let jsonData = message.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
+                let json = JSON(data: jsonData)
+                
+                self.parseFayeMessage(json)
+            }
         }
     }
     

--- a/Sources/FayeClient+Subscriptions.swift
+++ b/Sources/FayeClient+Subscriptions.swift
@@ -21,11 +21,13 @@ extension FayeClient {
     }
     
     func resubscribeToPendingSubscriptions() {
-        print("Faye: Resubscribing to all pending(\(pendingSubscriptions.count)) subscriptions")
-        
-        for channel in pendingSubscriptions {
-            removeChannelFromPendingSubscriptions(channel.subscription)
-            subscribeToChannel(channel)
+        if !pendingSubscriptions.isEmpty {
+            print("Faye: Resubscribing to \(pendingSubscriptions.count) pending subscriptions")
+            
+            for channel in pendingSubscriptions {
+                removeChannelFromPendingSubscriptions(channel.subscription)
+                subscribeToChannel(channel)
+            }
         }
     }
     

--- a/Sources/FayeClient+Subscriptions.swift
+++ b/Sources/FayeClient+Subscriptions.swift
@@ -70,6 +70,9 @@ extension FayeClient {
     // MARK: Subscriptions
     
     func removeChannelFromQueuedSubscriptions(channel: String) -> Bool {
+        objc_sync_enter(self.queuedSubscriptions)
+        defer { objc_sync_exit(self.queuedSubscriptions) }
+        
         let index = self.queuedSubscriptions.indexOf { $0.subscription == channel }
         
         if let index = index {
@@ -82,6 +85,9 @@ extension FayeClient {
     }
     
     func removeChannelFromPendingSubscriptions(channel: String) -> Bool {
+        objc_sync_enter(self.pendingSubscriptions)
+        defer { objc_sync_exit(self.pendingSubscriptions) }
+        
         let index = self.pendingSubscriptions.indexOf { $0.subscription == channel }
         
         if let index = index {
@@ -94,6 +100,9 @@ extension FayeClient {
     }
     
     func removeChannelFromOpenSubscriptions(channel: String) -> Bool {
+        objc_sync_enter(self.pendingSubscriptions)
+        defer { objc_sync_exit(self.pendingSubscriptions) }
+        
         let index = self.openSubscriptions.indexOf { $0.subscription == channel }
         
         if let index = index {

--- a/Sources/FayeClient+Subscriptions.swift
+++ b/Sources/FayeClient+Subscriptions.swift
@@ -1,0 +1,100 @@
+//
+//  FayeClient+Subscriptions.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 19/07/2016.
+//
+//
+
+import Foundation
+import SwiftyJSON
+
+// MARK: Private Internal methods
+extension FayeClient {
+    func subscribeQueuedSubscriptions() {
+        // if there are any outstanding open subscriptions resubscribe
+        for channel in self.queuedSubscriptions {
+            removeChannelFromQueuedSubscriptions(channel.subscription)
+            subscribeToChannel(channel)
+        }
+    }
+    
+    func resubscribeToPendingSubscriptions() {
+        print("Faye: Resubscribing to all pending(\(pendingSubscriptions.count)) subscriptions")
+        
+        for channel in pendingSubscriptions {
+            removeChannelFromPendingSubscriptions(channel.subscription)
+            subscribeToChannel(channel)
+        }
+    }
+    
+    func unsubscribeAllSubscriptions() {
+        let all = queuedSubscriptions + openSubscriptions + pendingSubscriptions
+        
+        all.forEach({ unsubscribeFromChannel($0.subscription) })
+    }
+    
+    func send(message: NSDictionary) {
+        // Parse JSON
+        if let string = JSON(message).rawString() {
+            self.transport?.writeString(string)
+        }
+    }
+    
+    func receive(message: String) {
+        // Parse JSON
+        if let jsonData = message.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
+            let json = JSON(data: jsonData)
+            self.parseFayeMessage(json)
+        }
+    }
+    
+    func nextMessageId() -> String {
+        self.messageNumber += 1
+        
+        if self.messageNumber >= UINT32_MAX {
+            messageNumber = 0
+        }
+        
+        return "\(self.messageNumber)".encodedString()
+    }
+    
+    // MARK:
+    // MARK: Subscriptions
+    
+    func removeChannelFromQueuedSubscriptions(channel: String) -> Bool {
+        let index = self.queuedSubscriptions.indexOf { $0.subscription == channel }
+        
+        if let index = index {
+            self.queuedSubscriptions.removeAtIndex(index)
+            
+            return true
+        }
+        
+        return false
+    }
+    
+    func removeChannelFromPendingSubscriptions(channel: String) -> Bool {
+        let index = self.pendingSubscriptions.indexOf { $0.subscription == channel }
+        
+        if let index = index {
+            self.pendingSubscriptions.removeAtIndex(index)
+            
+            return true
+        }
+        
+        return false
+    }
+    
+    func removeChannelFromOpenSubscriptions(channel: String) -> Bool {
+        let index = self.openSubscriptions.indexOf { $0.subscription == channel }
+        
+        if let index = index {
+            self.openSubscriptions.removeAtIndex(index)
+            
+            return true
+        }
+        
+        return false
+    }
+}

--- a/Sources/FayeClient+Transport.swift
+++ b/Sources/FayeClient+Transport.swift
@@ -1,0 +1,41 @@
+//
+//  FayeClient+Transport.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 19/07/2016.
+//
+//
+
+import Foundation
+
+// MARK: Transport Delegate
+extension FayeClient {
+    public func didConnect() {
+        self.connectionInitiated = false;
+        self.handshake()
+    }
+    
+    public func didDisconnect(error: NSError?) {
+        self.delegate?.disconnectedFromServer(self)
+        self.connectionInitiated = false
+        self.fayeConnected = false
+    }
+    
+    public func didFailConnection(error: NSError?) {
+        self.delegate?.connectionFailed(self)
+        self.connectionInitiated = false
+        self.fayeConnected = false
+    }
+    
+    public func didWriteError(error: NSError?) {
+        self.delegate?.fayeClientError(self, error: error ?? NSError(error: .TransportWrite))
+    }
+    
+    public func didReceiveMessage(text: String) {
+        self.receive(text)
+    }
+    
+    public func didReceivePong() {
+        self.delegate?.pongReceived(self)
+    }
+}

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -51,7 +51,7 @@ public class FayeClient : TransportDelegate {
   var pendingSubscriptions = Array<FayeSubscriptionModel>()
   var openSubscriptions = Array<FayeSubscriptionModel>()
 
-  var channelSubscriptionBlocks = Dictionary<String,ChannelSubscriptionBlock>()
+  var channelSubscriptionBlocks = Dictionary<String, ChannelSubscriptionBlock>()
 
   lazy var pendingSubscriptionSchedule: NSTimer = {
         return NSTimer.scheduledTimerWithTimeInterval(

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -346,7 +346,7 @@ private extension FayeClient {
   // "clientId": "Un1q31d3nt1f13r",
   // "connectionType": "long-polling"
   func connect() {
-    let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Connect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue]
+    let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Connect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue, "advice": ["timeout": 0]]
 
     if let string = JSON(dict).rawString() {
       self.transport?.writeString(string)

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -129,6 +129,8 @@ public class FayeClient : TransportDelegate {
   }
 
   public func disconnectFromServer() {
+    unsubscribeAllSubscriptions()
+    
     self.disconnect()
   }
 

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -423,7 +423,7 @@ private extension FayeClient {
   func subscribeQueuedSubscriptions() {
     // if there are any outstanding open subscriptions resubscribe
     for channel in self.queuedSubscriptions {
-      self.subscribe(channel)
+      subscribe(channel)
       removeChannelFromQueuedSubscriptions(channel.subscription)
     }
   }
@@ -436,11 +436,15 @@ private extension FayeClient {
   }
     
   func addExistingOpenSubscriptionsToQueued() {
-    self.queuedSubscriptions.appendContentsOf(self.openSubscriptions)
-    self.openSubscriptions.removeAll(keepCapacity: true)
+    if !self.openSubscriptions.isEmpty {
+      self.queuedSubscriptions.appendContentsOf(self.openSubscriptions)
+      self.openSubscriptions.removeAll(keepCapacity: true)
+    }
     
-    self.queuedSubscriptions.appendContentsOf(self.pendingSubscriptions)
-    self.pendingSubscriptions.removeAll()
+    if !self.pendingSubscriptions.isEmpty {
+      self.queuedSubscriptions.appendContentsOf(self.pendingSubscriptions)
+      self.pendingSubscriptions.removeAll()
+    }
   }
 
   func send(message: NSDictionary) {

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -48,7 +48,14 @@ public typealias ChannelSubscriptionBlock = (NSDictionary) -> Void
 
 // MARK: FayeClient
 public class FayeClient : TransportDelegate {
-  public var fayeURLString:String
+  public var fayeURLString:String {
+    didSet {
+      if let transport = self.transport {
+        transport.urlString = fayeURLString
+      }
+    }
+  }
+    
   public var fayeClientId:String?
   public weak var delegate:FayeClientDelegate?
   
@@ -243,7 +250,7 @@ private extension FayeClient {
               self.delegate?.messageReceived(self, messageDict: data as! NSDictionary, channel: channel)
             }
           } else {
-            print("For some reason data is nil, maybe double posting?!")
+            print("For some reason data is nil, maybe double posting?")
           }
         } else {
           print("weird channel")

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -36,7 +36,8 @@ public class FayeClient : TransportDelegate {
   public weak var delegate:FayeClientDelegate?
   
   var transport:WebsocketTransport?
-  var fayeConnected:Bool? {
+  
+  public internal(set) var fayeConnected:Bool? {
     didSet {
       if fayeConnected == false {
         unsubscribeAllSubscriptions()

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -15,7 +15,7 @@ public enum FayeSubscriptionState {
     case Subscribed(FayeSubscriptionModel)
     case Queued(FayeSubscriptionModel)
     case SubscribingTo(FayeSubscriptionModel)
-    case Unknown(FayeSubscriptionModel)
+    case Unknown(FayeSubscriptionModel?)
 }
 
 // MARK: BayuexChannel Messages

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -367,7 +367,7 @@ private extension FayeClient {
   // "channel": "/meta/subscribe",
   // "clientId": "Un1q31d3nt1f13r",
   // "subscription": "/foo/**"
-  func subscribe(model:FayeSubscriptionModel) {
+  func subscribe(var model:FayeSubscriptionModel) {
     do {
         let json = try model.jsonString()
         

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -270,7 +270,7 @@ private extension FayeClient {
               self.openSubscriptions.append(FayeSubscriptionModel(subscription: subscription, clientId: fayeClientId))
               self.delegate?.didSubscribeToChannel(self, channel: subscription)
             } else {
-              print("Missing subscription for Subscribe")
+              print("Faye: Missing subscription for Subscribe")
             }
           } else {
             // Subscribe Failed
@@ -289,7 +289,7 @@ private extension FayeClient {
             removeChannelFromOpenSubscriptions(subscription)
             self.delegate?.didUnsubscribeFromChannel(self, channel: subscription)
           } else {
-            print("Missing subscription for Unsubscribe")
+            print("Faye: Missing subscription for Unsubscribe")
           }
         }
       } else {
@@ -310,14 +310,14 @@ private extension FayeClient {
               channel: channel
             )
           } else {
-            print("For some reason data is nil, maybe double posting?")
+            print("Faye: For some reason data is nil for channel: \(channel)")
           }
         } else {
-          print("weird channel that not been set to subscribed")
+          print("Faye: Weird channel that not been set to subscribed: \(channel)")
         }
       }
     } else {
-      print("Missing channel")
+      print("Faye: Missing channel for \(messageDict)")
     }
   }
 
@@ -413,7 +413,7 @@ private extension FayeClient {
       let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: channel, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.Id.rawValue: self.nextMessageId(), Bayeux.Data.rawValue: data]
 
       if let string = JSON(dict).rawString() {
-        print("THIS IS THE PUBSLISH STRING: \(string)")
+        print("Faye: Publish string: \(string)")
         self.transport?.writeString(string)
       }
     } else {
@@ -433,6 +433,8 @@ private extension FayeClient {
   }
 
   func resubscribeToPendingSubscriptions() {
+    print("Faye: Resubscribing to all pending(\(pendingSubscriptions.count)) subscriptions")
+    
     for channel in pendingSubscriptions {
       removeChannelFromPendingSubscriptions(channel.subscription)
       subscribeToChannel(channel)
@@ -513,13 +515,11 @@ private extension FayeClient {
   @objc
   func pendingSubscriptionsAction(timer: NSTimer) {
     guard fayeConnected == true else {
-      print("Faye: Failed to resubscribe to pending, socket disconnected!!")
+      print("Faye: Failed to resubscribe to all pending channels, socket disconnected")
       
       return
     }
     
     resubscribeToPendingSubscriptions()
-    
-    print("Faye: Resubscribing to all pending subscriptions")
   }
 }

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -71,7 +71,7 @@ public class FayeClient : TransportDelegate {
   private var fayeConnected:Bool? {
     didSet {
       if fayeConnected == false {
-        addExistingOpenSubscriptionsToPending()
+        addExistingOpenSubscriptionsToQueued()
       }
     }
   }
@@ -435,12 +435,12 @@ private extension FayeClient {
     }
   }
     
-  func addExistingOpenSubscriptionsToPending() {
-    self.pendingSubscriptions.appendContentsOf(self.openSubscriptions)
+  func addExistingOpenSubscriptionsToQueued() {
+    self.queuedSubscriptions.appendContentsOf(self.openSubscriptions)
     self.openSubscriptions.removeAll(keepCapacity: true)
     
-    self.pendingSubscriptions.appendContentsOf(self.queuedSubscriptions)
-    self.queuedSubscriptions.removeAll()
+    self.queuedSubscriptions.appendContentsOf(self.pendingSubscriptions)
+    self.pendingSubscriptions.removeAll()
   }
 
   func send(message: NSDictionary) {

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -290,11 +290,16 @@ private extension FayeClient {
         if self.isSubscribedToChannel(channel) {
           if messageJSON[0][Bayeux.Data.rawValue] != JSON.null {
             let data: AnyObject = messageJSON[0][Bayeux.Data.rawValue].object
+            
             if let channelBlock = self.channelSubscriptionBlocks[channel] {
               channelBlock(data as! NSDictionary)
-            } else {
-              self.delegate?.messageReceived(self, messageDict: data as! NSDictionary, channel: channel)
             }
+            
+            self.delegate?.messageReceived(
+              self,
+              messageDict: data as! NSDictionary,
+              channel: channel
+            )
           } else {
             print("For some reason data is nil, maybe double posting?")
           }

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -15,6 +15,7 @@ public enum FayeSubscriptionState {
     case Subscribed(FayeSubscriptionModel)
     case Queued(FayeSubscriptionModel)
     case SubscribingTo(FayeSubscriptionModel)
+    case Unknown(FayeSubscriptionModel)
 }
 
 // MARK: BayuexChannel Messages

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -330,6 +330,7 @@ private extension FayeClient {
   // "supportedConnectionTypes": ["long-polling", "callback-polling", "iframe", "websocket]
   func handshake() {
     let connTypes:NSArray = [BayeuxConnection.LongPolling.rawValue, BayeuxConnection.Callback.rawValue, BayeuxConnection.iFrame.rawValue, BayeuxConnection.WebSocket.rawValue]
+    
     var dict = [String: AnyObject]()
     dict[Bayeux.Channel.rawValue] = BayeuxChannel.Handshake.rawValue
     dict[Bayeux.Version.rawValue] = "1.0"
@@ -446,6 +447,9 @@ private extension FayeClient {
       self.queuedSubscriptions.appendContentsOf(self.pendingSubscriptions)
       self.pendingSubscriptions.removeAll()
     }
+    
+    // reconnecting to socket creates a new ID
+    self.queuedSubscriptions.forEach({ $0.clientId = nil })
   }
 
   func send(message: NSDictionary) {

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -18,38 +18,6 @@ public enum FayeSubscriptionState {
     case Unknown(FayeSubscriptionModel?)
 }
 
-// MARK: BayuexChannel Messages
-public enum BayeuxChannel: String {
-    case Handshake = "/meta/handshake"
-    case Connect = "/meta/connect"
-    case Disconnect = "/meta/disconnect"
-    case Subscribe = "/meta/subscribe"
-    case Unsubscibe = "/meta/unsubscribe"
-}
-
-// MARK: Bayuex Parameters
-public enum Bayeux: String {
-    case Channel = "channel"
-    case Version = "version"
-    case ClientId = "clientId"
-    case ConnectionType = "connectionType"
-    case Data = "data"
-    case Subscription = "subscription"
-    case Id = "id"
-    case MinimumVersion = "minimumVersion"
-    case SupportedConnectionTypes = "supportedConnectionTypes"
-    case Successful = "successful"
-    case Error = "error"
-}
-
-// MARK: Bayuex Connection Type
-public enum BayeuxConnection: String {
-    case LongPolling = "long-polling"
-    case Callback = "callback-polling"
-    case iFrame = "iframe"
-    case WebSocket = "websocket"
-}
-
 // MARK: Type Aliases
 public typealias ChannelSubscriptionBlock = (NSDictionary) -> Void
 
@@ -67,8 +35,8 @@ public class FayeClient : TransportDelegate {
   public var fayeClientId:String?
   public weak var delegate:FayeClientDelegate?
   
-  private var transport:WebsocketTransport?
-  private var fayeConnected:Bool? {
+  var transport:WebsocketTransport?
+  var fayeConnected:Bool? {
     didSet {
       if fayeConnected == false {
         unsubscribeAllSubscriptions()
@@ -76,16 +44,16 @@ public class FayeClient : TransportDelegate {
     }
   }
   
-  private var connectionInitiated:Bool?
-  private var messageNumber:UInt32 = 0
+  var connectionInitiated:Bool?
+  var messageNumber:UInt32 = 0
 
-  private var queuedSubscriptions = Array<FayeSubscriptionModel>()
-  private var pendingSubscriptions = Array<FayeSubscriptionModel>()
-  private var openSubscriptions = Array<FayeSubscriptionModel>()
+  var queuedSubscriptions = Array<FayeSubscriptionModel>()
+  var pendingSubscriptions = Array<FayeSubscriptionModel>()
+  var openSubscriptions = Array<FayeSubscriptionModel>()
 
-  private var channelSubscriptionBlocks = Dictionary<String,ChannelSubscriptionBlock>()
+  var channelSubscriptionBlocks = Dictionary<String,ChannelSubscriptionBlock>()
 
-  private lazy var pendingSubscriptionSchedule: NSTimer = {
+  lazy var pendingSubscriptionSchedule: NSTimer = {
         return NSTimer.scheduledTimerWithTimeInterval(
             45,
             target: self,
@@ -118,7 +86,9 @@ public class FayeClient : TransportDelegate {
   deinit {
     pendingSubscriptionSchedule.invalidate()
   }
-    
+
+  
+  // MARK: Client
   public func connectToServer() {
     if self.connectionInitiated != true {
       self.transport?.openConnection()
@@ -182,344 +152,5 @@ public class FayeClient : TransportDelegate {
     
     removeChannelFromOpenSubscriptions(channel)
     removeChannelFromPendingSubscriptions(channel)
-  }
-
-  public func isSubscribedToChannel(channel:String) -> Bool {
-    return self.openSubscriptions.contains { $0.subscription == channel }
-  }
-
-  public func isTransportConnected() -> Bool {
-    return self.transport!.isConnected()
-  }
-}
-
-
-// MARK: Transport Delegate
-extension FayeClient {
-  public func didConnect() {
-    self.connectionInitiated = false;
-    self.handshake()
-  }
-
-  public func didDisconnect(error: NSError?) {
-    self.delegate?.disconnectedFromServer(self)
-    self.connectionInitiated = false
-    self.fayeConnected = false
-  }
-
-  public func didFailConnection(error: NSError?) {
-    self.delegate?.connectionFailed(self)
-    self.connectionInitiated = false
-    self.fayeConnected = false
-  }
-
-  public func didWriteError(error: NSError?) {
-    self.delegate?.fayeClientError(self, error: error ?? NSError(error: .TransportWrite))
-  }
-
-  public func didReceiveMessage(text: String) {
-    self.receive(text)
-  }
-    
-  public func didReceivePong() {
-    self.delegate?.pongReceived(self)
-  }
-}
-
-// MARK: Private Bayuex Methods
-private extension FayeClient {
-
-  func parseFayeMessage(messageJSON:JSON) {
-    let messageDict = messageJSON[0]
-    if let channel = messageDict[Bayeux.Channel.rawValue].string {
-
-      // Handle Meta Channels
-      if let metaChannel = BayeuxChannel(rawValue: channel) {
-        switch(metaChannel) {
-        case .Handshake:
-          self.fayeClientId = messageDict[Bayeux.ClientId.rawValue].stringValue
-          if messageDict[Bayeux.Successful.rawValue].int == 1 {
-            self.delegate?.connectedToServer(self)
-            self.fayeConnected = true;
-            self.connect()
-            self.subscribeQueuedSubscriptions()
-            pendingSubscriptionSchedule.valid
-          } else {
-            // OOPS
-          }
-        case .Connect:
-          if messageDict[Bayeux.Successful.rawValue].int == 1 {
-            self.fayeConnected = true;
-            self.connect()
-          } else {
-            // OOPS
-          }
-        case .Disconnect:
-          if messageDict[Bayeux.Successful.rawValue].int == 1 {
-            self.fayeConnected = false;
-            self.transport?.closeConnection()
-            self.delegate?.disconnectedFromServer(self)
-          } else {
-            // OOPS
-          }
-        case .Subscribe:
-          if let success = messageJSON[0][Bayeux.Successful.rawValue].int where success == 1 {
-            if let subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
-              removeChannelFromPendingSubscriptions(subscription)
-              
-              self.openSubscriptions.append(FayeSubscriptionModel(subscription: subscription, clientId: fayeClientId))
-              self.delegate?.didSubscribeToChannel(self, channel: subscription)
-            } else {
-              print("Faye: Missing subscription for Subscribe")
-            }
-          } else {
-            // Subscribe Failed
-            if let error = messageJSON[0][Bayeux.Error.rawValue].string,
-            subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
-              removeChannelFromPendingSubscriptions(subscription)
-                
-              self.delegate?.subscriptionFailedWithError(
-                self,
-                error: subscriptionError.error(subscription: subscription, error: error)
-              )
-            }
-          }
-        case .Unsubscibe:
-          if let subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
-            removeChannelFromOpenSubscriptions(subscription)
-            self.delegate?.didUnsubscribeFromChannel(self, channel: subscription)
-          } else {
-            print("Faye: Missing subscription for Unsubscribe")
-          }
-        }
-      } else {
-        // Handle Client Channel
-        if self.isSubscribedToChannel(channel) {
-          if messageJSON[0][Bayeux.Data.rawValue] != JSON.null {
-            let data: AnyObject = messageJSON[0][Bayeux.Data.rawValue].object
-            
-            if let channelBlock = self.channelSubscriptionBlocks[channel] {
-              channelBlock(data as! NSDictionary)
-            } else {
-                print("Faye: Failed to get channel block for : \(channel)")
-            }
-            
-            self.delegate?.messageReceived(
-              self,
-              messageDict: data as! NSDictionary,
-              channel: channel
-            )
-          } else {
-            print("Faye: For some reason data is nil for channel: \(channel)")
-          }
-        } else {
-          print("Faye: Weird channel that not been set to subscribed: \(channel)")
-        }
-      }
-    } else {
-      print("Faye: Missing channel for \(messageDict)")
-    }
-  }
-
-  /**
-   Bayeux messages
-   */
-
-  // Bayeux Handshake
-  // "channel": "/meta/handshake",
-  // "version": "1.0",
-  // "minimumVersion": "1.0beta",
-  // "supportedConnectionTypes": ["long-polling", "callback-polling", "iframe", "websocket]
-  func handshake() {
-    let connTypes:NSArray = [BayeuxConnection.LongPolling.rawValue, BayeuxConnection.Callback.rawValue, BayeuxConnection.iFrame.rawValue, BayeuxConnection.WebSocket.rawValue]
-    
-    var dict = [String: AnyObject]()
-    dict[Bayeux.Channel.rawValue] = BayeuxChannel.Handshake.rawValue
-    dict[Bayeux.Version.rawValue] = "1.0"
-    dict[Bayeux.MinimumVersion.rawValue] = "1.0beta"
-    dict[Bayeux.SupportedConnectionTypes.rawValue] = connTypes
-
-    if let string = JSON(dict).rawString() {
-      self.transport?.writeString(string)
-    }
-  }
-
-  // Bayeux Connect
-  // "channel": "/meta/connect",
-  // "clientId": "Un1q31d3nt1f13r",
-  // "connectionType": "long-polling"
-  func connect() {
-    let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Connect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue, "advice": ["timeout": 0]]
-
-    if let string = JSON(dict).rawString() {
-      self.transport?.writeString(string)
-    }
-  }
-
-  // Bayeux Disconnect
-  // "channel": "/meta/disconnect",
-  // "clientId": "Un1q31d3nt1f13r"
-  func disconnect() {
-    let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Disconnect.rawValue, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.ConnectionType.rawValue: BayeuxConnection.WebSocket.rawValue]
-    if let string = JSON(dict).rawString() {
-      self.transport?.writeString(string)
-    }
-  }
-
-  // Bayeux Subscribe
-  // "channel": "/meta/subscribe",
-  // "clientId": "Un1q31d3nt1f13r",
-  // "subscription": "/foo/**"
-  func subscribe(var model:FayeSubscriptionModel) {
-    do {
-        let json = try model.jsonString()
-        
-        self.transport?.writeString(json)
-        self.pendingSubscriptions.append(model)
-    } catch FayeSubscriptionModelError.ConversationError {
-        
-    } catch FayeSubscriptionModelError.ClientIdNotValid where fayeClientId?.characters.count > 0 {
-        model.clientId = fayeClientId
-        subscribe(model)
-    } catch {
-        
-    }
-  }
-
-  // Bayeux Unsubscribe
-  // {
-  // "channel": "/meta/unsubscribe",
-  // "clientId": "Un1q31d3nt1f13r",
-  // "subscription": "/foo/**"
-  // }
-  func unsubscribe(channel:String) {
-    if let clientId = self.fayeClientId {
-      let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: BayeuxChannel.Unsubscibe.rawValue, Bayeux.ClientId.rawValue: clientId, Bayeux.Subscription.rawValue: channel]
-      if let string = JSON(dict).rawString() {
-        self.transport?.writeString(string)
-      }
-    }
-  }
-
-  // Bayeux Publish
-  // {
-  // "channel": "/some/channel",
-  // "clientId": "Un1q31d3nt1f13r",
-  // "data": "some application string or JSON encoded object",
-  // "id": "some unique message id"
-  // }
-  func publish(data:[String:AnyObject], channel:String) {
-    if self.fayeConnected == true {
-      let dict:[String:AnyObject] = [Bayeux.Channel.rawValue: channel, Bayeux.ClientId.rawValue: self.fayeClientId!, Bayeux.Id.rawValue: self.nextMessageId(), Bayeux.Data.rawValue: data]
-
-      if let string = JSON(dict).rawString() {
-        print("Faye: Publish string: \(string)")
-        self.transport?.writeString(string)
-      }
-    } else {
-      // Faye is not connected
-    }
-  }
-}
-
-// MARK: Private Internal methods
-private extension FayeClient {
-  func subscribeQueuedSubscriptions() {
-    // if there are any outstanding open subscriptions resubscribe
-    for channel in self.queuedSubscriptions {
-      removeChannelFromQueuedSubscriptions(channel.subscription)
-      subscribeToChannel(channel)
-    }
-  }
-
-  func resubscribeToPendingSubscriptions() {
-    print("Faye: Resubscribing to all pending(\(pendingSubscriptions.count)) subscriptions")
-    
-    for channel in pendingSubscriptions {
-      removeChannelFromPendingSubscriptions(channel.subscription)
-      subscribeToChannel(channel)
-    }
-  }
-    
-  func unsubscribeAllSubscriptions() {
-    let all = queuedSubscriptions + openSubscriptions + pendingSubscriptions
-    
-    all.forEach({ unsubscribeFromChannel($0.subscription) })
-  }
-
-  func send(message: NSDictionary) {
-    // Parse JSON
-    if let string = JSON(message).rawString() {
-      self.transport?.writeString(string)
-    }
-  }
-
-  func receive(message: String) {
-    // Parse JSON
-    if let jsonData = message.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
-      let json = JSON(data: jsonData)
-      self.parseFayeMessage(json)
-    }
-  }
-
-  func nextMessageId() -> String {
-    self.messageNumber += 1
-    
-    if self.messageNumber >= UINT32_MAX {
-      messageNumber = 0
-    }
-    
-    return "\(self.messageNumber)".encodedString()
-  }
-
-  // MARK:
-  // MARK: Subscriptions
-  
-  private func removeChannelFromQueuedSubscriptions(channel: String) -> Bool {
-    let index = self.queuedSubscriptions.indexOf { $0.subscription == channel }
-    
-    if let index = index {
-      self.queuedSubscriptions.removeAtIndex(index)
-        
-      return true
-    }
-    
-    return false
-  }
-
-  private func removeChannelFromPendingSubscriptions(channel: String) -> Bool {
-    let index = self.pendingSubscriptions.indexOf { $0.subscription == channel }
-    
-    if let index = index {
-      self.pendingSubscriptions.removeAtIndex(index)
-        
-      return true
-    }
-    
-    return false
-  }
-
-  private func removeChannelFromOpenSubscriptions(channel: String) -> Bool {
-    let index = self.openSubscriptions.indexOf { $0.subscription == channel }
-    
-    if let index = index {
-      self.openSubscriptions.removeAtIndex(index)
-        
-      return true
-    }
-    
-    return false
-  }
-    
-  // MARK: Private - Timer Action
-  @objc
-  func pendingSubscriptionsAction(timer: NSTimer) {
-    guard fayeConnected == true else {
-      print("Faye: Failed to resubscribe to all pending channels, socket disconnected")
-      
-      return
-    }
-    
-    resubscribeToPendingSubscriptions()
   }
 }

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -267,9 +267,12 @@ private extension FayeClient {
             // Subscribe Failed
             if let error = messageJSON[0][Bayeux.Error.rawValue].string,
             subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
+              removeChannelFromPendingSubscriptions(subscription)
+                
               self.delegate?.subscriptionFailedWithError(
                 self,
-                error: subscriptionError.error(subscription: subscription, error: error))
+                error: subscriptionError.error(subscription: subscription, error: error)
+              )
             }
           }
         case .Unsubscibe:

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -63,7 +63,7 @@ public class FayeClient : TransportDelegate {
         )
     }()
 
-  let readOperationQueue = dispatch_queue_create("com.hamin.fayeclient.read", DISPATCH_QUEUE_CONCURRENT)
+  let readOperationQueue = dispatch_queue_create("com.hamin.fayeclient.read", DISPATCH_QUEUE_SERIAL)
   let writeOperationQueue = dispatch_queue_create("com.hamin.fayeclient.write", DISPATCH_QUEUE_CONCURRENT)
     
   // MARK: Init

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -71,7 +71,7 @@ public class FayeClient : TransportDelegate {
   private var fayeConnected:Bool? {
     didSet {
       if fayeConnected == false {
-        addExistingOpenSubscriptionsToQueued()
+        unsubscribeAllSubscriptions()
       }
     }
   }
@@ -437,19 +437,10 @@ private extension FayeClient {
     }
   }
     
-  func addExistingOpenSubscriptionsToQueued() {
-    if !self.openSubscriptions.isEmpty {
-      self.queuedSubscriptions.appendContentsOf(self.openSubscriptions)
-      self.openSubscriptions.removeAll(keepCapacity: true)
-    }
+  func unsubscribeAllSubscriptions() {
+    let all = queuedSubscriptions + openSubscriptions + pendingSubscriptions
     
-    if !self.pendingSubscriptions.isEmpty {
-      self.queuedSubscriptions.appendContentsOf(self.pendingSubscriptions)
-      self.pendingSubscriptions.removeAll()
-    }
-    
-    // reconnecting to socket creates a new ID
-    self.queuedSubscriptions.forEach({ $0.clientId = nil })
+    all.forEach({ unsubscribeFromChannel($0.subscription) })
   }
 
   func send(message: NSDictionary) {

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -116,6 +116,10 @@ public class FayeClient : TransportDelegate {
   public func sendMessage(messageDict:[String:AnyObject], channel:String) {
     self.publish(messageDict, channel: channel)
   }
+    
+  public func sendPing(data: NSData, completion: (() -> ())?) {
+    self.transport?.sendPing(data, completion: completion)
+  }
 
   public func subscribeToChannel(model:FayeSubscriptionModel, block:ChannelSubscriptionBlock?=nil) -> FayeSubscriptionState {
     guard !self.isSubscribedToChannel(model.subscription) else {

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -515,7 +515,9 @@ private extension FayeClient {
   // MARK: Private - Timer Action
   @objc
   func pendingSubscriptionsAction(timer: NSTimer) {
-    guard fayeConnected == true && pendingSubscriptions.isEmpty == false else {
+    guard fayeConnected == true else {
+      print("Faye: Failed to resubscribe to pending, socket disconnected!!")
+      
       return
     }
     

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -68,7 +68,13 @@ public class FayeClient : TransportDelegate {
   public weak var delegate:FayeClientDelegate?
   
   private var transport:WebsocketTransport?
-  private var fayeConnected:Bool?
+  private var fayeConnected:Bool? {
+    didSet {
+      if fayeConnected == false {
+        addExistingOpenSubscriptionsToPending()
+      }
+    }
+  }
   
   private var connectionInitiated:Bool?
   private var messageNumber:UInt32 = 0
@@ -428,6 +434,14 @@ private extension FayeClient {
       subscribe(channel)
     }
   }
+    
+  func addExistingOpenSubscriptionsToPending() {
+    self.pendingSubscriptions.appendContentsOf(self.openSubscriptions)
+    self.openSubscriptions.removeAll(keepCapacity: true)
+    
+    self.pendingSubscriptions.appendContentsOf(self.queuedSubscriptions)
+    self.queuedSubscriptions.removeAll()
+  }
 
   func send(message: NSDictionary) {
     // Parse JSON
@@ -502,6 +516,6 @@ private extension FayeClient {
     
     resubscribeToPendingSubscriptions()
     
-    print("resubscribing to all pending subscriptions")
+    print("Faye: Resubscribing to all pending subscriptions")
   }
 }

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -86,17 +86,16 @@ public class FayeClient : TransportDelegate {
   private var channelSubscriptionBlocks = Dictionary<String,ChannelSubscriptionBlock>()
 
   private lazy var pendingSubscriptionSchedule: NSTimer = {
-        let timer = NSTimer.scheduledTimerWithTimeInterval(
+        return NSTimer.scheduledTimerWithTimeInterval(
             45,
             target: self,
             selector: #selector(pendingSubscriptionsAction(_:)),
             userInfo: nil, 
             repeats: true
         )
-        
-        return timer
     }()
-    
+
+  // MARK: Init
   public init(aFayeURLString:String, channel:String?) {
     self.fayeURLString = aFayeURLString
     self.fayeConnected = false;
@@ -299,6 +298,8 @@ private extension FayeClient {
             
             if let channelBlock = self.channelSubscriptionBlocks[channel] {
               channelBlock(data as! NSDictionary)
+            } else {
+                print("Faye: Failed to get channel block for : \(channel)")
             }
             
             self.delegate?.messageReceived(
@@ -310,7 +311,7 @@ private extension FayeClient {
             print("For some reason data is nil, maybe double posting?")
           }
         } else {
-          print("weird channel")
+          print("weird channel that not been set to subscribed")
         }
       }
     } else {
@@ -423,15 +424,15 @@ private extension FayeClient {
   func subscribeQueuedSubscriptions() {
     // if there are any outstanding open subscriptions resubscribe
     for channel in self.queuedSubscriptions {
-      subscribe(channel)
       removeChannelFromQueuedSubscriptions(channel.subscription)
+      subscribeToChannel(channel)
     }
   }
 
   func resubscribeToPendingSubscriptions() {
     for channel in pendingSubscriptions {
       removeChannelFromPendingSubscriptions(channel.subscription)
-      subscribe(channel)
+      subscribeToChannel(channel)
     }
   }
     

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -385,20 +385,27 @@ private extension FayeClient {
   }
     
   private func removeChannelFromQueuedSubscriptions(channel: String) {
-    for (idx, element) in self.queuedSubscriptions.enumerate() where element.subscription == channel {
-      self.queuedSubscriptions.removeAtIndex(idx)
+    let index = self.queuedSubscriptions.indexOf { $0.subscription == channel }
+    
+    if let index = index {
+        self.queuedSubscriptions.removeAtIndex(index)
     }
+    
   }
 
   private func removeChannelFromPendingSubscriptions(channel: String) {
-    for (idx, element) in self.pendingSubscriptions.enumerate() where element.subscription == channel {
-      self.pendingSubscriptions.removeAtIndex(idx)
+    let index = self.pendingSubscriptions.indexOf { $0.subscription == channel }
+    
+    if let index = index {
+        self.pendingSubscriptions.removeAtIndex(index)
     }
   }
 
   private func removeChannelFromOpenSubscriptions(channel: String) {
-    for (idx, element) in self.openSubscriptions.enumerate() where element.subscription == channel {
-      self.openSubscriptions.removeAtIndex(idx)
+    let index = self.openSubscriptions.indexOf { $0.subscription == channel }
+    
+    if let index = index {
+        self.openSubscriptions.removeAtIndex(index)
     }
   }
 }

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -191,7 +191,10 @@ extension FayeClient {
   public func didReceiveMessage(text: String) {
     self.receive(text)
   }
-
+    
+  public func didReceivePong() {
+    self.delegate?.pongReceived(self)
+  }
 }
 
 // MARK: Private Bayuex Methods

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -217,8 +217,11 @@ private extension FayeClient {
             }
           } else {
             // Subscribe Failed
-            if let error = messageJSON[0][Bayeux.Error.rawValue].string {
-              self.delegate?.subscriptionFailedWithError(self, error: error)
+            if let error = messageJSON[0][Bayeux.Error.rawValue].string,
+            subscription = messageJSON[0][Bayeux.Subscription.rawValue].string {
+              self.delegate?.subscriptionFailedWithError(
+                self,
+                error: subscriptionError.error(subscription: subscription, error: error))
             }
           }
         case .Unsubscibe:

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -118,6 +118,8 @@ public class FayeClient : TransportDelegate {
     if self.connectionInitiated != true {
       self.transport?.openConnection()
       self.connectionInitiated = true;
+    } else {
+        print("Faye: Connection established")
     }
   }
 

--- a/Sources/FayeClient.swift
+++ b/Sources/FayeClient.swift
@@ -63,14 +63,18 @@ public class FayeClient : TransportDelegate {
         )
     }()
 
+  /// Default in 10 seconds
+  let timeOut: Int
+
   let readOperationQueue = dispatch_queue_create("com.hamin.fayeclient.read", DISPATCH_QUEUE_SERIAL)
   let writeOperationQueue = dispatch_queue_create("com.hamin.fayeclient.write", DISPATCH_QUEUE_CONCURRENT)
     
   // MARK: Init
-  public init(aFayeURLString:String, channel:String?) {
+  public init(aFayeURLString:String, channel:String?, timeoutAdvice:Int=10000) {
     self.fayeURLString = aFayeURLString
     self.fayeConnected = false;
-
+    self.timeOut = timeoutAdvice
+    
     self.transport = WebsocketTransport(url: aFayeURLString)
     self.transport!.delegate = self;
 

--- a/Sources/FayeClientDelegate.swift
+++ b/Sources/FayeClientDelegate.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+public enum subscriptionError: ErrorType {
+    case error(subscription: String, error: String)
+}
+
 // MARK: FayeClientDelegate Protocol
 public protocol FayeClientDelegate: NSObjectProtocol {
   func messageReceived(client:FayeClient, messageDict: NSDictionary, channel: String)
@@ -16,7 +20,7 @@ public protocol FayeClientDelegate: NSObjectProtocol {
   func connectionFailed(client:FayeClient)
   func didSubscribeToChannel(client:FayeClient, channel:String)
   func didUnsubscribeFromChannel(client:FayeClient, channel:String)
-  func subscriptionFailedWithError(client:FayeClient, error:String)
+  func subscriptionFailedWithError(client:FayeClient, error:subscriptionError)
   func fayeClientError(client:FayeClient, error:NSError)
 }
 
@@ -27,6 +31,6 @@ public extension FayeClientDelegate {
   func connectionFailed(client:FayeClient){}
   func didSubscribeToChannel(client:FayeClient, channel:String){}
   func didUnsubscribeFromChannel(client:FayeClient, channel:String){}
-  func subscriptionFailedWithError(client:FayeClient, error:String){}
+  func subscriptionFailedWithError(client:FayeClient, error:subscriptionError){}
   func fayeClientError(client:FayeClient, error:NSError){}
 }

--- a/Sources/FayeClientDelegate.swift
+++ b/Sources/FayeClientDelegate.swift
@@ -15,6 +15,7 @@ public enum subscriptionError: ErrorType {
 // MARK: FayeClientDelegate Protocol
 public protocol FayeClientDelegate: NSObjectProtocol {
   func messageReceived(client:FayeClient, messageDict: NSDictionary, channel: String)
+  func pongReceived(client:FayeClient)
   func connectedToServer(client:FayeClient)
   func disconnectedFromServer(client:FayeClient)
   func connectionFailed(client:FayeClient)
@@ -26,6 +27,7 @@ public protocol FayeClientDelegate: NSObjectProtocol {
 
 public extension FayeClientDelegate {
   func messageReceived(client:FayeClient, messageDict: NSDictionary, channel: String){}
+  func pongReceived(client:FayeClient){}
   func connectedToServer(client:FayeClient){}
   func disconnectedFromServer(client:FayeClient){}
   func connectionFailed(client:FayeClient){}

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -26,7 +26,7 @@ public class FayeSubscriptionModel {
     /// Channel type for request
     public let channel: BayeuxChannel
     
-    /// Uniqle client id
+    /// Uniqle client id for socket
     public var clientId: String?
     
     /// Model must conform to Hashable

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -80,7 +80,7 @@ public class FayeSubscriptionModel {
 extension FayeSubscriptionModel: CustomStringConvertible {
     
     public var description: String {
-        return "\(String(self)): \(try? self.toDictionary())"
+        return "FayeSubscriptionModel: \(try? self.toDictionary())"
     }
 }
 

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -18,7 +18,7 @@ public enum FayeSubscriptionModelError: ErrorType {
 // MARK: FayeSubscriptionModel
 
 ///  Subscription Model
-public struct FayeSubscriptionModel {
+public class FayeSubscriptionModel {
     
     /// Subscription URL
     public let subscription: String

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -1,0 +1,82 @@
+//
+//  FayeSubscriptionModel.swift
+//  Pods
+//
+//  Created by Shams Ahmed on 25/04/2016.
+//
+//
+
+import Foundation
+import SwiftyJSON
+
+public enum FayeSubscriptionModelError: ErrorType {
+    case ConversationError
+    case ClientIdNotValid
+}
+
+// MARK:
+// MARK: FayeSubscriptionModel
+
+///  Subscription Model
+public class FayeSubscriptionModel {
+    
+    /// Subscription URL
+    public let subscription: String
+    
+    /// Channel type for request
+    public let channel: BayeuxChannel
+    
+    /// Uniqle client id
+    public var clientId: String?
+    
+    /// Model must conform to Hashable
+    public var hashValue: Int {
+        return subscription.hashValue
+    }
+    
+    // MARK:
+    // MARK: Init
+    
+    public init(subscription: String, channel: BayeuxChannel=BayeuxChannel.Subscribe, clientId: String?) {
+        self.subscription = subscription
+        self.channel = channel
+        self.clientId = clientId
+    }
+    
+    // MARK:
+    // MARK: JSON
+    
+    ///  Return Json string from model
+    public func jsonString() throws -> String {
+        do {
+            guard let model = try JSON(toDictionary()).rawString() else {
+                throw FayeSubscriptionModelError.ConversationError
+            }
+            
+            return model
+        } catch {
+            throw FayeSubscriptionModelError.ClientIdNotValid
+        }
+    }
+    
+    // MARK:
+    // MARK: Helper
+    
+    ///  Create dictionary of model object, Subclasses should override method to return custom model
+    public func toDictionary() throws -> [String: String] {
+        guard let clientId = clientId else {
+            throw FayeSubscriptionModelError.ClientIdNotValid
+        }
+        
+        return [Bayeux.Channel.rawValue: channel.rawValue,
+                Bayeux.ClientId.rawValue: clientId,
+                Bayeux.Subscription.rawValue: subscription]
+    }
+}
+
+// MARK:
+// MARK: Equatable
+
+public func ==(lhs: FayeSubscriptionModel, rhs: FayeSubscriptionModel) -> Bool {
+    return lhs.hashValue == rhs.hashValue
+}

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -18,7 +18,7 @@ public enum FayeSubscriptionModelError: ErrorType {
 // MARK: FayeSubscriptionModel
 
 ///  Subscription Model
-public class FayeSubscriptionModel {
+public struct FayeSubscriptionModel {
     
     /// Subscription URL
     public let subscription: String

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -74,6 +74,16 @@ public class FayeSubscriptionModel {
     }
 }
 
+// MARK: 
+// MARK: Description
+
+extension FayeSubscriptionModel: CustomStringConvertible {
+    
+    public var description: String {
+        return "subscription: \(self.subscription), channel: \(self.channel.rawValue), clientId: \(self.clientId)"
+    }
+}
+
 // MARK:
 // MARK: Equatable
 

--- a/Sources/FayeSubscriptionModel.swift
+++ b/Sources/FayeSubscriptionModel.swift
@@ -80,7 +80,7 @@ public class FayeSubscriptionModel {
 extension FayeSubscriptionModel: CustomStringConvertible {
     
     public var description: String {
-        return "subscription: \(self.subscription), channel: \(self.channel.rawValue), clientId: \(self.clientId)"
+        return "\(String(self)): \(try? self.toDictionary())"
     }
 }
 

--- a/Sources/NSError+Helper.swift
+++ b/Sources/NSError+Helper.swift
@@ -13,11 +13,12 @@ public enum FayeSocketError {
 }
 
 public extension NSError {
+    
     // MARK:
     // MARK: Error
     
     /// Helper to create a error object for faye realted issues
     convenience init(error: FayeSocketError) {
-        self.init(domain: "", code: 10000, userInfo: nil)
+        self.init(domain: "com.hamin.fayeswift", code: 10000, userInfo: nil)
     }
 }

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -16,22 +16,26 @@ extension String {
   func encodedString() -> String {
     // UTF 8 str from original
     // NSData! type returned (optional)
-    let utf8str = self.dataUsingEncoding(NSUTF8StringEncoding)
+    guard let utf8str = self.dataUsingEncoding(NSUTF8StringEncoding) else {
+        return ""
+    }
     
     // Base64 encode UTF 8 string
     // fromRaw(0) is equivalent to objc 'base64EncodedStringWithOptions:0'
     // Notice the unwrapping given the NSData! optional
     // NSString! returned (optional)
-    let base64Encoded = utf8str?.base64EncodedStringWithOptions(NSDataBase64EncodingOptions())
+    let base64Encoded = utf8str.base64EncodedStringWithOptions(NSDataBase64EncodingOptions())
     
     // Base64 Decode (go back the other way)
     // Notice the unwrapping given the NSString! optional
     // NSData returned
-    let data = NSData(base64EncodedString: base64Encoded!, options: NSDataBase64DecodingOptions())
+    guard let data = NSData(
+        base64EncodedString: base64Encoded,
+        options: NSDataBase64DecodingOptions()),
+    base64Decoded = NSString(data: data, encoding: NSUTF8StringEncoding) else {
+            return ""
+    }
     
-    // Convert back to a string
-    let base64Decoded = NSString(data: data!, encoding: NSUTF8StringEncoding)
-    
-    return base64Decoded! as String
+    return base64Decoded as String
   }
 }

--- a/Sources/Transport.swift
+++ b/Sources/Transport.swift
@@ -19,4 +19,5 @@ public protocol TransportDelegate: class {
   func didDisconnect(error: NSError?)
   func didWriteError(error:NSError?)
   func didReceiveMessage(text:String)
+  func didReceivePong()
 }

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -29,16 +29,17 @@ internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDe
       webSocket.pongDelegate = self
       webSocket.connect()
         
-      print("Faye: Opening connection")
+      print("Faye: Opening connection with \(self.urlString)")
     }
   }
   
   func closeConnection() {
-    print("Faye: Closing connection")
-    
     if let webSocket = self.webSocket {
+      print("Faye: Closing connection")
+        
       webSocket.delegate = nil
       webSocket.disconnect(forceTimeout: 0)
+      
       self.webSocket = nil
     }
   }

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -38,7 +38,7 @@ internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDe
     
     if let webSocket = self.webSocket {
       webSocket.delegate = nil
-      webSocket.disconnect()
+      webSocket.disconnect(forceTimeout: 0)
       self.webSocket = nil
     }
   }

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Starscream
 
-internal class WebsocketTransport: Transport, WebSocketDelegate {
+internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDelegate {
   var urlString:String?
   var webSocket:WebSocket?
   internal weak var delegate:TransportDelegate?
@@ -24,7 +24,8 @@ internal class WebsocketTransport: Transport, WebSocketDelegate {
     self.webSocket = WebSocket(url: NSURL(string:self.urlString!)!)
     
     if let webSocket = self.webSocket {
-      webSocket.delegate = self;
+      webSocket.delegate = self
+      webSocket.pongDelegate = self
       webSocket.connect()
     }
   }
@@ -66,5 +67,10 @@ internal class WebsocketTransport: Transport, WebSocketDelegate {
   internal func websocketDidReceiveData(socket: WebSocket, data: NSData) {
     print("got some data: \(data.length)")
     //self.socket.writeData(data)
+  }
+
+  // MARK: WebSocket Pong Delegate
+  internal func websocketDidReceivePong(socket: WebSocket) {
+    self.delegate?.didReceivePong()
   }
 }

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -74,7 +74,7 @@ internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDe
   
   // MARK: TODO
   internal func websocketDidReceiveData(socket: WebSocket, data: NSData) {
-    print("got some data: \(data.length)")
+    print("Faye: Received data: \(data.length)")
     //self.socket.writeData(data)
   }
 

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -42,6 +42,10 @@ internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDe
     self.webSocket?.writeString(aString)
   }
   
+  func sendPing(data: NSData, completion: (() -> ())? = nil) {
+    self.webSocket?.writePing(data, completion: completion)
+  }
+  
   func isConnected() -> (Bool) {
     return self.webSocket?.isConnected ?? false
   }

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -16,6 +16,7 @@ internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDe
   
   convenience required internal init(url: String) {
     self.init()
+    
     self.urlString = url
   }
   
@@ -27,10 +28,14 @@ internal class WebsocketTransport: Transport, WebSocketDelegate, WebSocketPongDe
       webSocket.delegate = self
       webSocket.pongDelegate = self
       webSocket.connect()
+        
+      print("Faye: Opening connection")
     }
   }
   
   func closeConnection() {
+    print("Faye: Closing connection")
+    
     if let webSocket = self.webSocket {
       webSocket.delegate = nil
       webSocket.disconnect()

--- a/Sources/WebsocketTransport.swift
+++ b/Sources/WebsocketTransport.swift
@@ -22,15 +22,18 @@ internal class WebsocketTransport: Transport, WebSocketDelegate {
   func openConnection() {
     self.closeConnection()
     self.webSocket = WebSocket(url: NSURL(string:self.urlString!)!)
-    self.webSocket!.delegate = self;
-    self.webSocket!.connect()
+    
+    if let webSocket = self.webSocket {
+      webSocket.delegate = self;
+      webSocket.connect()
+    }
   }
   
   func closeConnection() {
-    if self.webSocket != nil {
-      self.webSocket!.delegate = nil
-      self.webSocket!.disconnect()
-      self.webSocket = nil;
+    if let webSocket = self.webSocket {
+      webSocket.delegate = nil
+      webSocket.disconnect()
+      self.webSocket = nil
     }
   }
   


### PR DESCRIPTION
**Fixes:**
- Uncalled disconnect when there socket issues
- Removed force wraps to prevent crashes
- Crash when converting model to JSON in new model
- Uncalled messages delegate method
- Pending subscriptions were not removed if socket errored out 

**Features/Improvements:**
- Added configurable timeout advice 
- Read/Write multi-threading
- Moved to enum based solution for Faye models 
- Helper methods to remove subscriptions
- Made client Id public to allow it to change i.e when we reconnecting Faye send a new iD
- Resubscribe to pending subscription timer
- Move to a model based solution for all subscriptions 
- Ping/Pong Faye socket

**General:**
- Refactored code base to use external extension 
- Cleaner console logs
- CocoaPods update
- XCode 7 updates

